### PR TITLE
Add #[non_exhaustive] to the huge enums.

### DIFF
--- a/src/any.rs
+++ b/src/any.rs
@@ -8,6 +8,7 @@ macro_rules! any {
         /// Any of the supported atoms.
         #[derive(Clone, PartialEq)]
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[non_exhaustive]
         pub enum Any {
             $($kind($kind),)*
             Unknown(FourCC, Vec<u8>),

--- a/src/moov/trak/mdia/minf/stbl/stsd/mod.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/mod.rs
@@ -26,6 +26,7 @@ pub struct Stsd {
 /// Called a "sample entry" in the ISOBMFF specification.
 #[derive(Debug, Clone, PartialEq, Eq, From)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub enum Codec {
     // H264
     Avc1(Avc1),


### PR DESCRIPTION
Don't want to force an error or major version bump each time.