### PR TITLE
feat: add support for BitRateBox (btrt)

### DIFF
--- a/src/any.rs
+++ b/src/any.rs
@@ -142,6 +142,7 @@ any! {
                         Stsd,
                             Avc1,
                                 Avcc,
+                                Btrt,
                                 Colr,
                                 Pasp,
                             Hev1, Hvc1,

--- a/src/moov/mod.rs
+++ b/src/moov/mod.rs
@@ -212,6 +212,7 @@ mod test {
                                             ]],
                                             ext: None,
                                         },
+                                        btrt: None,
                                         colr: None,
                                         pasp: None,
                                     }

--- a/src/moov/trak/mdia/minf/stbl/stsd/btrt.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/btrt.rs
@@ -1,0 +1,42 @@
+use crate::*;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Btrt {
+    pub buffer_size_db: u32,
+    pub max_bitrate: u32,
+    pub avg_bitrate: u32,
+}
+
+impl Btrt {
+    pub fn new(buffer_size_db: u32, max_bitrate: u32, avg_bitrate: u32) -> Result<Self> {
+        Ok(Self {
+            buffer_size_db,
+            max_bitrate,
+            avg_bitrate,
+        })
+    }
+}
+
+impl Atom for Btrt {
+    const KIND: FourCC = FourCC::new(b"btrt");
+
+    fn decode_body<B: Buf>(buf: &mut B) -> Result<Self> {
+        let buffer_size_db = u32::decode(buf)?;
+        let max_bitrate = u32::decode(buf)?;
+        let avg_bitrate = u32::decode(buf)?;
+
+        Ok(Btrt {
+            buffer_size_db,
+            max_bitrate,
+            avg_bitrate,
+        })
+    }
+
+    fn encode_body<B: BufMut>(&self, buf: &mut B) -> Result<()> {
+        self.buffer_size_db.encode(buf)?;
+        self.max_bitrate.encode(buf)?;
+        self.avg_bitrate.encode(buf)?;
+        Ok(())
+    }
+}

--- a/src/moov/trak/mdia/minf/stbl/stsd/hevc/hev1.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/hevc/hev1.rs
@@ -5,6 +5,7 @@ use crate::*;
 pub struct Hev1 {
     pub visual: Visual,
     pub hvcc: Hvcc,
+    pub btrt: Option<Btrt>,
     pub colr: Option<Colr>,
     pub pasp: Option<Pasp>,
 }
@@ -16,11 +17,13 @@ impl Atom for Hev1 {
         let visual = Visual::decode(buf)?;
 
         let mut hvcc = None;
+        let mut btrt = None;
         let mut colr = None;
         let mut pasp = None;
         while let Some(atom) = Any::decode_maybe(buf)? {
             match atom {
                 Any::Hvcc(atom) => hvcc = atom.into(),
+                Any::Btrt(atom) => btrt = atom.into(),
                 Any::Colr(atom) => colr = atom.into(),
                 Any::Pasp(atom) => pasp = atom.into(),
                 _ => tracing::warn!("unknown atom: {:?}", atom),
@@ -30,6 +33,7 @@ impl Atom for Hev1 {
         Ok(Hev1 {
             visual,
             hvcc: hvcc.ok_or(Error::MissingBox(Hvcc::KIND))?,
+            btrt,
             colr,
             pasp,
         })
@@ -38,6 +42,9 @@ impl Atom for Hev1 {
     fn encode_body<B: BufMut>(&self, buf: &mut B) -> Result<()> {
         self.visual.encode(buf)?;
         self.hvcc.encode(buf)?;
+        if self.btrt.is_some() {
+            self.btrt.encode(buf)?;
+        }
         if self.colr.is_some() {
             self.colr.encode(buf)?;
         }
@@ -70,6 +77,7 @@ mod tests {
                 configuration_version: 1,
                 ..Default::default()
             },
+            btrt: None,
             colr: None,
             pasp: None,
         };

--- a/src/moov/trak/mdia/minf/stbl/stsd/hevc/hvcc.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/hevc/hvcc.rs
@@ -169,6 +169,7 @@ mod tests {
                 configuration_version: 1,
                 ..Default::default()
             },
+            btrt: None,
             colr: None,
             pasp: None,
         };

--- a/src/moov/trak/mdia/minf/stbl/stsd/mod.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/mod.rs
@@ -1,4 +1,5 @@
 mod av01;
+mod btrt;
 mod colr;
 mod h264;
 mod hevc;
@@ -9,6 +10,7 @@ mod visual;
 mod vp9;
 
 pub use av01::*;
+pub use btrt::*;
 pub use colr::*;
 pub use h264::*;
 pub use hevc::*;

--- a/src/test/av1.rs
+++ b/src/test/av1.rs
@@ -227,6 +227,11 @@ fn av1() {
                                             10, 11, 0, 0, 0, 74, 171, 191, 195, 119, 255, 231, 1
                                         ]
                                     },
+                                    btrt: Some(Btrt {
+                                        buffer_size_db: 0,
+                                        max_bitrate: 914496,
+                                        avg_bitrate: 914496
+                                    }),
                                     colr: None,
                                     pasp: None,
                                 }

--- a/src/test/bbb.rs
+++ b/src/test/bbb.rs
@@ -263,6 +263,7 @@ fn bbb() {
                                         picture_parameter_sets:  vec![b"h\xee2\xc8\xb0".into()],
                                         ext: None,
                                     },
+                                    btrt: Some(Btrt { buffer_size_db: 0, max_bitrate: 1991287, avg_bitrate: 1991287 }),
                                     colr: None,
                                     pasp: Some(Pasp {
                                         h_spacing: 1,
@@ -341,6 +342,7 @@ fn bbb() {
                                             sl_config: esds::SLConfig{},
                                         },
                                     }),
+                                    btrt: Some(Btrt { buffer_size_db: 0, max_bitrate: 125587, avg_bitrate: 125587 }),
                                 }
                                 .into()],
                             },

--- a/src/test/esds.rs
+++ b/src/test/esds.rs
@@ -192,6 +192,7 @@ fn esds() {
                                         picture_parameter_sets:  vec![b"h\xce\x0f\xc8".into()],
                                         ext: None,
                                     },
+                                    btrt: None,
                                     colr: None,
                                     pasp: Some(Pasp {
                                         h_spacing: 1,
@@ -270,6 +271,7 @@ fn esds() {
                                             sl_config: esds::SLConfig{},
                                         },
                                     }),
+                                    btrt: Some(Btrt { buffer_size_db: 0, max_bitrate: 128000, avg_bitrate: 128000 }),
                                 }
                                 .into()],
                             },

--- a/src/test/h264.rs
+++ b/src/test/h264.rs
@@ -243,6 +243,11 @@ fn avcc_ext() {
                                             sequence_parameter_sets_ext: vec![],
                                         }),
                                     },
+                                    btrt: Some(Btrt {
+                                        buffer_size_db: 0,
+                                        max_bitrate: 2453499,
+                                        avg_bitrate: 2453499,
+                                    }),
                                     colr: Some(Colr::Nclx {
                                         colour_primaries: 1,
                                         transfer_characteristics: 1,
@@ -338,6 +343,11 @@ fn avcc_ext() {
                                             },
                                             sl_config: esds::SLConfig::default(),
                                         },
+                                    }),
+                                    btrt: Some(Btrt {
+                                        buffer_size_db: 0,
+                                        max_bitrate: 160000,
+                                        avg_bitrate: 160000,
                                     }),
                                 }
                                 .into()],

--- a/src/test/hevc.rs
+++ b/src/test/hevc.rs
@@ -555,6 +555,11 @@ fn hevc() {
                                             }
                                         ]
                                     },
+                                    btrt: Some(Btrt {
+                                        buffer_size_db: 0,
+                                        max_bitrate: 25175730,
+                                        avg_bitrate: 25175730
+                                    }),
                                     colr: None,
                                     pasp: Some(Pasp {
                                         h_spacing: 1,


### PR DESCRIPTION
This is from ISO/IEC 14496-12:2022 Section 8.5.2.

Most of the test data already has this box.