### PR TITLE
Relaxed reserved bits validation on `Avcc` decode

### DIFF
--- a/src/moov/trak/mdia/minf/stbl/stsd/h264/avcc.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/h264/avcc.rs
@@ -244,7 +244,7 @@ mod tests {
                 sequence_parameter_sets_ext: Vec::new(),
             }),
         };
-        let decoded = Avcc::decode(&mut buf).expect("avcc should decode successfully");
+        let decoded = Avcc::decode(&mut buf).expect("avcC should decode successfully");
         assert_eq!(avcc, decoded);
         let mut encoded = Vec::new();
         avcc.encode(&mut encoded)

--- a/src/moov/trak/mdia/minf/stbl/stsd/h264/avcc.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/h264/avcc.rs
@@ -202,7 +202,7 @@ mod tests {
 
     #[test]
     fn ok_in_range_is_err_when_out_of_range() {
-        match ok_in_range(9, 0..8) {
+        match ok_in_range(8, 0..8) {
             Err(Error::InvalidSize) => (),
             Ok(n) => panic!("unexpected Ok value Ok({n})"),
             Err(e) => panic!("unexpected error case {e}"),


### PR DESCRIPTION
Removes the validation for the reserved bits before `lengthSizeMinusOne` being `0b111111`.

Also, I found that the encode logic was slightly broken, in that it didn't account for re-introducing the reserved bits for the `ext` properties, and also subtracting the 8 that was added to `bit_depth_luma` and `bit_depth_chroma`.

I took precedent from the encode of `length_size` that checks that the number is in range and throws error if not before trying to encode... But this is a change in logic that _could_ break existing encodes. It is slightly different than the decode case, because the only way the number would be out of range, is if a user constructed the `Avcc` directly (using the struct properties) and set the number incorrectly... This couldn't happen when trying to encode an `Avcc` that was obtained from a decode because the reserved bits are discarded. I also don't want to indiscriminately mask with 1s because that could hide the input error / be unexpected. The other way I was thinking of taking was to only re-add the reserved mask if the bits were all zero, which would maintain compatibility with whatever is already written. Happy to hear feedback on it.

Fixes #54 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved decoding tolerance for H.264 configuration, accepting streams with nonstandard reserved bits.
  - Encoding now preserves reserved bits and validates bit-depth ranges, preventing invalid outputs.
  - More robust handling of chroma format and bit depths for better interoperability with varied files and encoders.
  - No public API changes.

- Tests
  - Added unit and round-trip tests covering range validation and reserved-bit behavior to ensure consistent decode/encode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->