### PR TITLE
ac3: add support for AC-3 sample entry and related dac3 box

### DIFF
--- a/src/any.rs
+++ b/src/any.rs
@@ -293,6 +293,8 @@ any! {
                                 Dfla,
                             Ac3,
                                 Ac3SpecificBox,
+                            Eac3,
+                                Ec3SpecificBox,
                         Stts,
                         Stsc,
                         Stsz,

--- a/src/any.rs
+++ b/src/any.rs
@@ -291,6 +291,8 @@ any! {
                                 UncC,
                             Flac,
                                 Dfla,
+                            Ac3,
+                                Ac3SpecificBox,
                         Stts,
                         Stsc,
                         Stsz,

--- a/src/moov/trak/mdia/minf/stbl/stsd/ac3.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/ac3.rs
@@ -1,0 +1,152 @@
+use crate::*;
+
+// See ETSI TS 102 366 V1.4.1 (2017-09) for details of AC-3 and EAC-3
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Ac3 {
+    pub audio: Audio,
+    pub dac3: Ac3SpecificBox,
+}
+
+impl Atom for Ac3 {
+    const KIND: FourCC = FourCC::new(b"ac-3");
+
+    fn decode_body<B: Buf>(buf: &mut B) -> Result<Self> {
+        let audio = Audio::decode(buf)?;
+
+        let mut dac3 = None;
+
+        while let Some(atom) = Any::decode_maybe(buf)? {
+            match atom {
+                Any::Ac3SpecificBox(atom) => dac3 = atom.into(),
+                _ => tracing::warn!("unknown atom: {:?}", atom),
+            }
+        }
+
+        Ok(Self {
+            audio,
+            dac3: dac3.ok_or(Error::MissingBox(Ac3SpecificBox::KIND))?,
+        })
+    }
+
+    fn encode_body<B: BufMut>(&self, buf: &mut B) -> Result<()> {
+        self.audio.encode(buf)?;
+        self.dac3.encode(buf)?;
+        Ok(())
+    }
+}
+
+// AC-3 specific data
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Ac3SpecificBox {
+    pub fscod: u8,
+    pub bsid: u8,
+    pub bsmod: u8,
+    pub acmod: u8,
+    pub lfeon: bool,
+    pub bit_rate_code: u8,
+}
+
+impl Atom for Ac3SpecificBox {
+    const KIND: FourCC = FourCC::new(b"dac3");
+
+    fn decode_body<B: Buf>(buf: &mut B) -> Result<Self> {
+        let body_bytes = u24::decode(buf)?;
+        let body: u32 = body_bytes.into();
+        let fscod = ((body >> 22) & 0b11) as u8;
+        let bsid = ((body >> 17) & 0b11111) as u8;
+        let bsmod = ((body >> 14) & 0b111) as u8;
+        let acmod = ((body >> 11) & 0b111) as u8;
+        let lfeon = ((body >> 10) & 0b1) == 0b1;
+        let bit_rate_code = ((body >> 5) & 0b11111) as u8;
+        Ok(Self {
+            fscod,
+            bsid,
+            bsmod,
+            acmod,
+            lfeon,
+            bit_rate_code,
+        })
+    }
+
+    fn encode_body<B: BufMut>(&self, buf: &mut B) -> Result<()> {
+        let body: u32 = ((self.bit_rate_code as u32) << 5)
+            | ((self.acmod as u32) << 11)
+            | ((self.bsmod as u32) << 14)
+            | ((self.bsid as u32) << 17)
+            | ((self.fscod as u32) << 22)
+            | (if self.lfeon { 0x1u32 << 10 } else { 0u32 });
+        let body_bytes: u24 = body
+            .try_into()
+            .map_err(|_| Error::TooLarge(Ac3SpecificBox::KIND))?;
+        body_bytes.encode(buf)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Streaminfo metadata block only
+    const ENCODED_AC3: &[u8] = &[
+        0x00, 0x00, 0x00, 0x2f, 0x61, 0x63, 0x2d, 0x33, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x10, 0x00, 0x00,
+        0x00, 0x00, 0xac, 0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0b, 0x64, 0x61, 0x63, 0x33, 0x50,
+        0x11, 0x40,
+    ];
+
+    #[test]
+    fn test_ac3_decode() {
+        let buf: &mut std::io::Cursor<&[u8]> = &mut std::io::Cursor::new(ENCODED_AC3);
+
+        let ac3 = Ac3::decode(buf).expect("failed to decode ac-3");
+
+        assert_eq!(
+            ac3,
+            Ac3 {
+                audio: Audio {
+                    data_reference_index: 1,
+                    channel_count: 2,
+                    sample_size: 16,
+                    sample_rate: 44100.into()
+                },
+                dac3: Ac3SpecificBox {
+                    fscod: 1,
+                    bsid: 8,
+                    bsmod: 0,
+                    acmod: 2,
+                    lfeon: false,
+                    bit_rate_code: 10
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_ac3_encode() {
+        let ac3 = Ac3 {
+            audio: Audio {
+                data_reference_index: 1,
+                channel_count: 2,
+                sample_size: 16,
+                sample_rate: 44100.into(),
+            },
+            dac3: Ac3SpecificBox {
+                fscod: 1,
+                bsid: 8,
+                bsmod: 0,
+                acmod: 2,
+                lfeon: false,
+                bit_rate_code: 10,
+            },
+        };
+
+        let mut buf = Vec::new();
+        ac3.encode(&mut buf).unwrap();
+
+        assert_eq!(buf.as_slice(), ENCODED_AC3);
+    }
+}

--- a/src/moov/trak/mdia/minf/stbl/stsd/eac3.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/eac3.rs
@@ -1,0 +1,214 @@
+use crate::*;
+
+// See ETSI TS 102 366 V1.4.1 (2017-09) for details of AC-3 and EAC-3
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Eac3 {
+    pub audio: Audio,
+    pub dec3: Ec3SpecificBox,
+}
+
+impl Atom for Eac3 {
+    const KIND: FourCC = FourCC::new(b"ec-3");
+
+    fn decode_body<B: Buf>(buf: &mut B) -> Result<Self> {
+        let audio = Audio::decode(buf)?;
+
+        let mut dec3 = None;
+
+        while let Some(atom) = Any::decode_maybe(buf)? {
+            match atom {
+                Any::Ec3SpecificBox(atom) => dec3 = atom.into(),
+                _ => tracing::warn!("unknown atom: {:?}", atom),
+            }
+        }
+
+        Ok(Self {
+            audio,
+            dec3: dec3.ok_or(Error::MissingBox(Ec3SpecificBox::KIND))?,
+        })
+    }
+
+    fn encode_body<B: BufMut>(&self, buf: &mut B) -> Result<()> {
+        self.audio.encode(buf)?;
+        self.dec3.encode(buf)?;
+        Ok(())
+    }
+}
+
+// EAC-3 specific data
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Ec3IndependentSubstream {
+    pub fscod: u8,
+    pub bsid: u8,
+    pub asvc: bool,
+    pub bsmod: u8,
+    pub acmod: u8,
+    pub lfeon: bool,
+    pub num_dep_sub: u8,
+    pub chan_loc: Option<u16>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Ec3SpecificBox {
+    data_rate: u16,
+    substreams: Vec<Ec3IndependentSubstream>,
+}
+
+impl Atom for Ec3SpecificBox {
+    const KIND: FourCC = FourCC::new(b"dec3");
+
+    fn decode_body<B: Buf>(buf: &mut B) -> Result<Self> {
+        let header = u16::decode(buf)?;
+        let data_rate = header >> 3;
+        let num_ind_sub = header & 0b111;
+        let mut substreams = Vec::with_capacity(num_ind_sub as usize);
+        for _ in 0..num_ind_sub {
+            let b0 = u8::decode(buf)?;
+            let fscod = b0 >> 6;
+            let bsid = (b0 >> 1) & 0b11111;
+            // ignore low bit - reserved
+            let b1 = u8::decode(buf)?;
+            let asvc = (b1 & 0x80) == 0x80;
+            let bsmod = (b1 >> 4) & 0b111;
+            let acmod = (b1 >> 1) & 0b111;
+            let lfeon = (b1 & 0b1) == 0b1;
+            let b2 = u8::decode(buf)?;
+            // ignore next three bits
+            let num_dep_sub = (b2 >> 1) & 0b1111;
+            if num_dep_sub > 0 {
+                let b3 = u8::decode(buf)? as u16;
+                let chan_loc = ((b2 as u16 & 0x01) << 8) | b3;
+                substreams.push(Ec3IndependentSubstream {
+                    fscod,
+                    bsid,
+                    asvc,
+                    bsmod,
+                    acmod,
+                    lfeon,
+                    num_dep_sub,
+                    chan_loc: Some(chan_loc),
+                });
+            } else {
+                // ignore last bit in b2
+                substreams.push(Ec3IndependentSubstream {
+                    fscod,
+                    bsid,
+                    asvc,
+                    bsmod,
+                    acmod,
+                    lfeon,
+                    num_dep_sub,
+                    chan_loc: None,
+                });
+            }
+        }
+        Ok(Self {
+            data_rate,
+            substreams,
+        })
+    }
+
+    fn encode_body<B: BufMut>(&self, buf: &mut B) -> Result<()> {
+        let header = self.data_rate << 3 | self.substreams.len() as u16;
+        header.encode(buf)?;
+        for substream in &self.substreams {
+            // low bit is reserved = 0
+            let b = (substream.fscod << 6) | (substream.bsid << 1);
+            b.encode(buf)?;
+            let b = (if substream.asvc { 0x80 } else { 0x00 })
+                | (substream.bsmod << 4)
+                | (substream.acmod << 1)
+                | (if substream.lfeon { 0x01 } else { 0x00 });
+            b.encode(buf)?;
+            if substream.num_dep_sub > 0 {
+                let b: u16 =
+                    ((substream.num_dep_sub as u16) << 9) | (substream.chan_loc.unwrap_or(0u16));
+                b.encode(buf)?;
+            } else {
+                // high and low bits are reserved = 0
+                let b = substream.num_dep_sub << 1;
+                b.encode(buf)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // EAC-3 metadata block only
+    const ENCODED_EAC3: &[u8] = &[
+        0x00, 0x00, 0x00, 0x31, 0x65, 0x63, 0x2d, 0x33, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x10, 0x00, 0x00,
+        0x00, 0x00, 0xac, 0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0d, 0x64, 0x65, 0x63, 0x33, 0x5f,
+        0xc1, 0x60, 0x04, 0x00,
+    ];
+
+    #[test]
+    fn test_eac3_decode() {
+        let buf: &mut std::io::Cursor<&[u8]> = &mut std::io::Cursor::new(ENCODED_EAC3);
+
+        let eac3 = Eac3::decode(buf).expect("failed to decode eac-3");
+
+        assert_eq!(
+            eac3,
+            Eac3 {
+                audio: Audio {
+                    data_reference_index: 1,
+                    channel_count: 2,
+                    sample_size: 16,
+                    sample_rate: 44100.into()
+                },
+                dec3: Ec3SpecificBox {
+                    data_rate: 3064,
+                    substreams: vec![Ec3IndependentSubstream {
+                        fscod: 1,
+                        bsid: 16,
+                        asvc: false,
+                        bsmod: 0,
+                        acmod: 2,
+                        lfeon: false,
+                        num_dep_sub: 0,
+                        chan_loc: None
+                    }]
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_eac3_encode() {
+        let eac3 = Eac3 {
+            audio: Audio {
+                data_reference_index: 1,
+                channel_count: 2,
+                sample_size: 16,
+                sample_rate: 44100.into(),
+            },
+            dec3: Ec3SpecificBox {
+                data_rate: 3064,
+                substreams: vec![Ec3IndependentSubstream {
+                    fscod: 1,
+                    bsid: 16,
+                    asvc: false,
+                    bsmod: 0,
+                    acmod: 2,
+                    lfeon: false,
+                    num_dep_sub: 0,
+                    chan_loc: None,
+                }],
+            },
+        };
+
+        let mut buf = Vec::new();
+        eac3.encode(&mut buf).unwrap();
+
+        assert_eq!(buf.as_slice(), ENCODED_EAC3);
+    }
+}

--- a/src/moov/trak/mdia/minf/stbl/stsd/mod.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/mod.rs
@@ -1,3 +1,4 @@
+mod ac3;
 mod audio;
 mod av01;
 mod btrt;
@@ -15,6 +16,7 @@ mod uncv;
 mod visual;
 mod vp9;
 
+pub use ac3::*;
 pub use audio::*;
 pub use av01::*;
 pub use btrt::*;
@@ -78,6 +80,9 @@ pub enum Codec {
     // FLAC audio
     Flac(Flac),
 
+    // AC-3 audio
+    Ac3(Ac3),
+
     // Unknown
     Unknown(FourCC),
 }
@@ -97,6 +102,7 @@ impl Decode for Codec {
             Any::Opus(atom) => atom.into(),
             Any::Uncv(atom) => atom.into(),
             Any::Flac(atom) => atom.into(),
+            Any::Ac3(atom) => atom.into(),
             Any::Unknown(kind, _) => Self::Unknown(kind),
             _ => return Err(Error::UnexpectedBox(atom.kind())),
         })
@@ -118,6 +124,7 @@ impl Encode for Codec {
             Self::Opus(atom) => atom.encode(buf),
             Self::Uncv(atom) => atom.encode(buf),
             Self::Flac(atom) => atom.encode(buf),
+            Self::Ac3(atom) => atom.encode(buf),
         }
     }
 }

--- a/src/moov/trak/mdia/minf/stbl/stsd/mod.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/mod.rs
@@ -4,6 +4,7 @@ mod av01;
 mod btrt;
 mod ccst;
 mod colr;
+mod eac3;
 mod flac;
 mod h264;
 mod hevc;
@@ -22,6 +23,7 @@ pub use av01::*;
 pub use btrt::*;
 pub use ccst::*;
 pub use colr::*;
+pub use eac3::*;
 pub use flac::*;
 pub use h264::*;
 pub use hevc::*;
@@ -83,6 +85,9 @@ pub enum Codec {
     // AC-3 audio
     Ac3(Ac3),
 
+    // EAC-3 audio
+    Eac3(Eac3),
+
     // Unknown
     Unknown(FourCC),
 }
@@ -103,6 +108,7 @@ impl Decode for Codec {
             Any::Uncv(atom) => atom.into(),
             Any::Flac(atom) => atom.into(),
             Any::Ac3(atom) => atom.into(),
+            Any::Eac3(atom) => atom.into(),
             Any::Unknown(kind, _) => Self::Unknown(kind),
             _ => return Err(Error::UnexpectedBox(atom.kind())),
         })
@@ -125,6 +131,7 @@ impl Encode for Codec {
             Self::Uncv(atom) => atom.encode(buf),
             Self::Flac(atom) => atom.encode(buf),
             Self::Ac3(atom) => atom.encode(buf),
+            Self::Eac3(atom) => atom.encode(buf),
         }
     }
 }


### PR DESCRIPTION
These are from Dolby, via ETSI TS 102 366.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Full AC-3 (Dolby Digital) and E-AC-3 (Dolby Digital Plus) atom support: decode, encode, and round-trip.
  - Codec variants integrated into the generic atom/codec handling so AC-3/E-AC-3 are discovered and serialized like existing codecs.
  - Public API exposes the new codec types for upstream use.

- **Tests**
  - Added unit tests validating decode/encode correctness and byte-accurate round-trips for AC-3 and E-AC-3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->