### PR TITLE
fix(eac3): make box members public

### DIFF
--- a/src/moov/trak/mdia/minf/stbl/stsd/eac3.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/eac3.rs
@@ -54,8 +54,8 @@ pub struct Ec3IndependentSubstream {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Ec3SpecificBox {
-    data_rate: u16,
-    substreams: Vec<Ec3IndependentSubstream>,
+    pub data_rate: u16,
+    pub substreams: Vec<Ec3IndependentSubstream>,
 }
 
 impl Atom for Ec3SpecificBox {


### PR DESCRIPTION
Inadvertently missed from previous commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced E-AC-3 metadata accessibility by exposing fields for data rate and substreams. Developers can now read and construct these values directly, enabling easier integration, inspection, and customization of E-AC-3 track details. This streamlines workflows that need precise audio stream parameters and improves interoperability with external tools. No behavioral changes to existing functionality; existing usage remains compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->