### PR TITLE
fix(eac3): uses the correct number of sub streams, consumes all remaining bytes by definition

### DIFF
--- a/src/moov/trak/mdia/minf/stbl/stsd/eac3.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/eac3.rs
@@ -106,6 +106,9 @@ impl Atom for Ec3SpecificBox {
                 });
             }
         }
+
+        // reserved bits may follow
+        buf.advance(buf.remaining());
         Ok(Self {
             data_rate,
             substreams,


### PR DESCRIPTION
closes #60 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved E-AC-3 configuration handling to support additional and dependent substreams.
  * Correctly skips reserved bits for better spec compliance.
  * Adjusted header encoding for greater compatibility with diverse E-AC-3 tracks.
  * Reduces parsing/encoding errors and improves stability.

* **Tests**
  * Expanded coverage for multiple/dependent substreams, reserved bits, and round-trip encode/decode.
  * Updated existing test vectors to reflect encoding changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->