### PR TITLE
Log unknown atoms instead of (sometimes) returning an error.

### DIFF
--- a/src/atom.rs
+++ b/src/atom.rs
@@ -8,6 +8,11 @@ pub trait Atom: Sized {
 
     fn decode_body<B: Buf>(buf: &mut B) -> Result<Self>;
     fn encode_body<B: BufMut>(&self, buf: &mut B) -> Result<()>;
+
+    /// Either logs or returns an error depending on the environment/flag.
+    fn decode_unknown(atom: &crate::Any) -> Result<()> {
+        crate::decode_unknown(atom, Self::KIND)
+    }
 }
 
 impl<T: Atom> Encode for T {
@@ -194,7 +199,7 @@ macro_rules! nested {
                         },)*
                         Any::Skip(atom) => tracing::debug!(size = atom.zeroed.size, "skipping skip box"),
                         Any::Free(atom) => tracing::debug!(size = atom.zeroed.size, "skipping free box"),
-                        unknown => crate::unexpected_atom(unknown)?,
+                        unknown => Self::decode_unknown(&unknown)?,
                     }
                 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use crate::FourCC;
+use crate::{Any, FourCC};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -70,14 +70,9 @@ pub enum Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Either logs or returns an error depending on the environment/flag.
-pub(crate) fn unexpected_box(kind: FourCC) -> Result<()> {
+pub(crate) fn decode_unknown(atom: &Any, parent: FourCC) -> Result<()> {
     // TODO return an error when the `strict` feature flag is enabled.
     // TODO return an error when run as a unit test, after fixing them.
-    tracing::warn!(%kind, "unexpected box");
+    tracing::warn!(kind = %atom.kind(), parent = %parent, "unexpected box");
     Ok(())
-}
-
-/// Either logs or returns an error depending on the environment/flag.
-pub(crate) fn unexpected_atom(atom: crate::Any) -> Result<()> {
-    unexpected_box(atom.kind())
 }

--- a/src/meta/ilst/mod.rs
+++ b/src/meta/ilst/mod.rs
@@ -34,7 +34,7 @@ impl Atom for Ilst {
                 Any::Year(atom) => year = atom.into(),
                 Any::Covr(atom) => covr = atom.into(),
                 Any::Desc(atom) => desc = atom.into(),
-                atom => crate::unexpected_atom(atom)?,
+                atom => Self::decode_unknown(&atom)?,
             }
         }
 

--- a/src/moov/trak/mdia/minf/stbl/stsd/ac3.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/ac3.rs
@@ -20,7 +20,7 @@ impl Atom for Ac3 {
         while let Some(atom) = Any::decode_maybe(buf)? {
             match atom {
                 Any::Ac3SpecificBox(atom) => dac3 = atom.into(),
-                unknown => crate::unexpected_atom(unknown)?,
+                unknown => Self::decode_unknown(&unknown)?,
             }
         }
 

--- a/src/moov/trak/mdia/minf/stbl/stsd/av01.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/av01.rs
@@ -32,7 +32,7 @@ impl Atom for Av01 {
                 Any::Colr(atom) => colr = atom.into(),
                 Any::Pasp(atom) => pasp = atom.into(),
                 Any::Taic(atom) => taic = atom.into(),
-                unknown => crate::unexpected_atom(unknown)?,
+                unknown => Self::decode_unknown(&unknown)?,
             }
         }
 

--- a/src/moov/trak/mdia/minf/stbl/stsd/eac3.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/eac3.rs
@@ -20,7 +20,7 @@ impl Atom for Eac3 {
         while let Some(atom) = Any::decode_maybe(buf)? {
             match atom {
                 Any::Ec3SpecificBox(atom) => dec3 = atom.into(),
-                unknown => crate::unexpected_atom(unknown)?,
+                unknown => Self::decode_unknown(&unknown)?,
             }
         }
 

--- a/src/moov/trak/mdia/minf/stbl/stsd/flac.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/flac.rs
@@ -17,7 +17,7 @@ impl Atom for Flac {
         while let Some(atom) = Any::decode_maybe(buf)? {
             match atom {
                 Any::Dfla(atom) => dfla = atom.into(),
-                unknown => crate::unexpected_atom(unknown)?,
+                unknown => Self::decode_unknown(&unknown)?,
             }
         }
 

--- a/src/moov/trak/mdia/minf/stbl/stsd/h264/avc1.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/h264/avc1.rs
@@ -29,7 +29,7 @@ impl Atom for Avc1 {
                 Any::Colr(atom) => colr = atom.into(),
                 Any::Pasp(atom) => pasp = atom.into(),
                 Any::Taic(atom) => taic = atom.into(),
-                unknown => crate::unexpected_atom(unknown)?,
+                unknown => Self::decode_unknown(&unknown)?,
             }
         }
 

--- a/src/moov/trak/mdia/minf/stbl/stsd/hevc/hev1.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/hevc/hev1.rs
@@ -29,7 +29,7 @@ impl Atom for Hev1 {
                 Any::Colr(atom) => colr = atom.into(),
                 Any::Pasp(atom) => pasp = atom.into(),
                 Any::Taic(atom) => taic = atom.into(),
-                unknown => crate::unexpected_atom(unknown)?,
+                unknown => Self::decode_unknown(&unknown)?,
             }
         }
 

--- a/src/moov/trak/mdia/minf/stbl/stsd/hevc/hvc1.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/hevc/hvc1.rs
@@ -30,7 +30,7 @@ impl Atom for Hvc1 {
                 Any::Colr(atom) => colr = atom.into(),
                 Any::Pasp(atom) => pasp = atom.into(),
                 Any::Taic(atom) => taic = atom.into(),
-                unknown => crate::unexpected_atom(unknown)?,
+                unknown => Self::decode_unknown(&unknown)?,
             }
         }
 

--- a/src/moov/trak/mdia/minf/stbl/stsd/mod.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/mod.rs
@@ -138,7 +138,10 @@ impl Decode for Codec {
             Any::Fl32(atom) => atom.into(),
             Any::Fl64(atom) => atom.into(),
             Any::S16l(atom) => atom.into(),
-            unknown => Self::Unknown(unknown.kind()),
+            unknown => {
+                crate::decode_unknown(&unknown, Stsd::KIND)?;
+                Self::Unknown(unknown.kind())
+            }
         })
     }
 }

--- a/src/moov/trak/mdia/minf/stbl/stsd/mp4a/mod.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/mp4a/mod.rs
@@ -29,7 +29,7 @@ impl Atom for Mp4a {
                 Any::Btrt(atom) => btrt = atom.into(),
                 Any::Esds(atom) => esds = atom.into(),
                 Any::Taic(atom) => taic = atom.into(),
-                unknown => crate::unexpected_atom(unknown)?,
+                unknown => Self::decode_unknown(&unknown)?,
             }
         }
 

--- a/src/moov/trak/mdia/minf/stbl/stsd/opus.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/opus.rs
@@ -19,7 +19,7 @@ impl Atom for Opus {
         while let Some(atom) = Any::decode_maybe(buf)? {
             match atom {
                 Any::Dops(atom) => dops = atom.into(),
-                unknown => crate::unexpected_atom(unknown)?,
+                unknown => Self::decode_unknown(&unknown)?,
             }
         }
 

--- a/src/moov/trak/mdia/minf/stbl/stsd/pcm.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/pcm.rs
@@ -107,7 +107,7 @@ impl Pcm {
                 match Any::decode_atom(&header, &mut limited)? {
                     Any::PcmC(atom) => pcmc = Some(atom),
                     Any::Btrt(atom) => btrt = Some(atom),
-                    atom => crate::unexpected_atom(atom)?,
+                    atom => crate::decode_unknown(&atom, fourcc)?,
                 }
             }
 

--- a/src/moov/trak/mdia/minf/stbl/stsd/uncv.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/uncv.rs
@@ -31,7 +31,7 @@ impl Atom for Uncv {
                 Any::Btrt(atom) => btrt = atom.into(),
                 Any::Ccst(atom) => ccst = atom.into(),
                 Any::Pasp(atom) => pasp = atom.into(),
-                unknown => crate::unexpected_atom(unknown)?,
+                unknown => Self::decode_unknown(&unknown)?,
             }
         }
 

--- a/src/moov/trak/mdia/minf/stbl/stsd/vp9/vp08.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/vp9/vp08.rs
@@ -18,7 +18,7 @@ impl Atom for Vp08 {
         while let Some(atom) = Any::decode_maybe(buf)? {
             match atom {
                 Any::VpcC(atom) => vpcc = atom.into(),
-                unknown => crate::unexpected_atom(unknown)?,
+                unknown => Self::decode_unknown(&unknown)?,
             }
         }
 

--- a/src/moov/trak/mdia/minf/stbl/stsd/vp9/vp09.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/vp9/vp09.rs
@@ -18,7 +18,7 @@ impl Atom for Vp09 {
         while let Some(atom) = Any::decode_maybe(buf)? {
             match atom {
                 Any::VpcC(atom) => vpcc = atom.into(),
-                unknown => crate::unexpected_atom(unknown)?,
+                unknown => Self::decode_unknown(&unknown)?,
             }
         }
 


### PR DESCRIPTION
We should enable this for unit tests, but currently the hevc test would fail. I don't want to create a feature flag until there's test coverage.

```
cargo test --features strict

---- test::hevc::hevc stdout ----

thread 'test::hevc::hevc' panicked at src/test/hevc.rs:214:34: failed to decode moov: UnexpectedBox(fiel)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Alternatively, we could use `tracing_test` to ensure that none of the unit tests have log output. That might be cleaner if we don't want a feature flag in the future.


Fixes #63 
Replaces #81 #71 