### PR TITLE
Make remaining bytes validation conditional on strict mode

### DIFF
--- a/src/any.rs
+++ b/src/any.rs
@@ -103,11 +103,8 @@ macro_rules! any {
                     },
                 };
 
-
-                if cfg!(feature = "strict") || cfg!(test) {
-                    if body.has_remaining() {
-                        return Err(Error::UnderDecode(header.kind));
-                    }
+                if (cfg!(feature = "strict") || cfg!(test)) && body.has_remaining() {
+                    return Err(Error::UnderDecode(header.kind));
                 }
 
                 buf.advance(size);

--- a/src/any.rs
+++ b/src/any.rs
@@ -103,8 +103,11 @@ macro_rules! any {
                     },
                 };
 
-                if body.has_remaining() {
-                    return Err(Error::UnderDecode(header.kind));
+
+                if cfg!(feature = "strict") || cfg!(test) {
+                    if body.has_remaining() {
+                        return Err(Error::UnderDecode(header.kind));
+                    }
                 }
 
                 buf.advance(size);

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -95,7 +95,7 @@ impl<T: Atom> ReadFrom for Option<T> {
             Err(err) => return Err(err),
         };
 
-        if body.has_remaining() {
+        if (cfg!(feature = "strict") || cfg!(test)) && body.has_remaining() {
             return Err(Error::UnderDecode(T::KIND));
         }
 

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -63,8 +63,10 @@ impl<T: Atom> DecodeMaybe for T {
             Err(err) => return Err(err),
         };
 
-        if body.has_remaining() {
-            return Err(Error::UnderDecode(T::KIND));
+        if cfg!(feature = "strict") || cfg!(test) {
+            if body.has_remaining() {
+                return Err(Error::UnderDecode(T::KIND));
+            }
         }
 
         buf.advance(size);
@@ -142,8 +144,10 @@ impl<T: Atom> DecodeAtom for T {
             Err(err) => return Err(err),
         };
 
-        if body.has_remaining() {
-            return Err(Error::UnderDecode(T::KIND));
+        if cfg!(feature = "strict") || cfg!(test) {
+            if body.has_remaining() {
+                return Err(Error::UnderDecode(T::KIND));
+            }
         }
 
         buf.advance(size);

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -63,10 +63,8 @@ impl<T: Atom> DecodeMaybe for T {
             Err(err) => return Err(err),
         };
 
-        if cfg!(feature = "strict") || cfg!(test) {
-            if body.has_remaining() {
-                return Err(Error::UnderDecode(T::KIND));
-            }
+        if (cfg!(feature = "strict") || cfg!(test)) && body.has_remaining() {
+            return Err(Error::UnderDecode(T::KIND));
         }
 
         buf.advance(size);
@@ -144,10 +142,8 @@ impl<T: Atom> DecodeAtom for T {
             Err(err) => return Err(err),
         };
 
-        if cfg!(feature = "strict") || cfg!(test) {
-            if body.has_remaining() {
-                return Err(Error::UnderDecode(T::KIND));
-            }
+        if (cfg!(feature = "strict") || cfg!(test)) && body.has_remaining() {
+            return Err(Error::UnderDecode(T::KIND));
         }
 
         buf.advance(size);

--- a/src/tokio/atom.rs
+++ b/src/tokio/atom.rs
@@ -37,7 +37,7 @@ impl<T: Atom> AsyncReadFrom for Option<T> {
             Err(err) => return Err(err),
         };
 
-        if buf.has_remaining() {
+        if (cfg!(feature = "strict") || cfg!(test)) && buf.has_remaining() {
             return Err(Error::UnderDecode(T::KIND));
         }
 


### PR DESCRIPTION
This PR makes non-strict builds more tolerant of leftover bytes in MP4 atom bodies, improving robustness when decoding real-world files. Strict validation remains unchanged for tests and strict-mode builds.