### PR TITLE
Add #[non_exhaustive] to Codec enum

### DIFF
--- a/src/moov/trak/mdia/minf/stbl/stsd/mod.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/mod.rs
@@ -56,6 +56,7 @@ pub struct Stsd {
 /// Called a "sample entry" in the ISOBMFF specification.
 #[derive(Debug, Clone, PartialEq, Eq, From)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub enum Codec {
     // H264
     Avc1(Avc1),


### PR DESCRIPTION
The Codec enum represents extensible sample entry types that may have
new variants added as new codecs are standardized.

https://claude.ai/code/session_01EAYgS4vZCZ7tTDXa38hHHa