### PR TITLE
iinf: Add support for "uri " infe boxes inside iinf

### DIFF
--- a/src/test/image.rs
+++ b/src/test/image.rs
@@ -63,6 +63,7 @@ fn heif() {
                             item_name: "".into(),
                             content_type: None,
                             content_encoding: None,
+                            item_uri_type: None,
                             item_not_in_presentation: false,
                         },
                         ItemInfoEntry {
@@ -72,6 +73,7 @@ fn heif() {
                             item_name: "".into(),
                             content_type: None,
                             content_encoding: None,
+                            item_uri_type: None,
                             item_not_in_presentation: false,
                         },
                     ]
@@ -331,6 +333,7 @@ fn avif() {
                         item_name: "Color".into(),
                         content_type: None,
                         content_encoding: None,
+                        item_uri_type: None,
                         item_not_in_presentation: false
                     }]
                 }


### PR DESCRIPTION
Adds the URI mode of creating infe boxes.

I'm not sure what your preference is with adding fields to the ItemInfoEntry structure ?