### PR TITLE
chore: fix up tests after recent commits

### DIFF
--- a/src/test/libavif_anim.rs
+++ b/src/test/libavif_anim.rs
@@ -185,7 +185,6 @@ fn av1_anim() {
                         }]
                     })
                 }),
-                meta: None,
                 mdia: Mdia {
                     mdhd: Mdhd {
                         creation_time: 3852424385,
@@ -278,11 +277,11 @@ fn av1_anim() {
                             ..Default::default()
                         },
                         ..Default::default()
-                    }
+                    },
                 },
                 ..Default::default()
             }],
-            udta: None,
+            ..Default::default()
         }
     );
 }


### PR DESCRIPTION
The specific error is that `ainf` is not initialised in `moov`. This change adds Default usage to make the tests more robust to future changes.