### PR TITLE
refactor: update related traits to support unsized reads and writes

### DIFF
--- a/src/any.rs
+++ b/src/any.rs
@@ -358,13 +358,13 @@ any! {
 }
 
 impl ReadFrom for Any {
-    fn read_from<R: Read>(r: &mut R) -> Result<Self> {
+    fn read_from<R: Read + ?Sized>(r: &mut R) -> Result<Self> {
         <Option<Any> as ReadFrom>::read_from(r)?.ok_or(Error::UnexpectedEof)
     }
 }
 
 impl ReadFrom for Option<Any> {
-    fn read_from<R: Read>(r: &mut R) -> Result<Self> {
+    fn read_from<R: Read + ?Sized>(r: &mut R) -> Result<Self> {
         let header = match <Option<Header> as ReadFrom>::read_from(r)? {
             Some(header) => header,
             None => return Ok(None),
@@ -376,7 +376,7 @@ impl ReadFrom for Option<Any> {
 }
 
 impl ReadAtom for Any {
-    fn read_atom<R: Read>(header: &Header, r: &mut R) -> Result<Self> {
+    fn read_atom<R: Read + ?Sized>(header: &Header, r: &mut R) -> Result<Self> {
         let body = &mut header.read_body(r)?;
         Any::decode_atom(header, body)
     }

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -74,13 +74,13 @@ impl<T: Atom> DecodeMaybe for T {
 }
 
 impl<T: Atom> ReadFrom for T {
-    fn read_from<R: Read>(r: &mut R) -> Result<Self> {
+    fn read_from<R: Read + ?Sized>(r: &mut R) -> Result<Self> {
         <Option<T> as ReadFrom>::read_from(r)?.ok_or(Error::MissingBox(T::KIND))
     }
 }
 
 impl<T: Atom> ReadFrom for Option<T> {
-    fn read_from<R: Read>(r: &mut R) -> Result<Self> {
+    fn read_from<R: Read + ?Sized>(r: &mut R) -> Result<Self> {
         let header = match <Option<Header> as ReadFrom>::read_from(r)? {
             Some(header) => header,
             None => return Ok(None),
@@ -104,13 +104,13 @@ impl<T: Atom> ReadFrom for Option<T> {
 }
 
 impl<T: Atom> ReadUntil for T {
-    fn read_until<R: Read>(r: &mut R) -> Result<Self> {
+    fn read_until<R: Read + ?Sized>(r: &mut R) -> Result<Self> {
         <Option<T> as ReadUntil>::read_until(r)?.ok_or(Error::MissingBox(T::KIND))
     }
 }
 
 impl<T: Atom> ReadUntil for Option<T> {
-    fn read_until<R: Read>(r: &mut R) -> Result<Self> {
+    fn read_until<R: Read + ?Sized>(r: &mut R) -> Result<Self> {
         while let Some(header) = <Option<Header> as ReadFrom>::read_from(r)? {
             if header.kind == T::KIND {
                 let body = &mut header.read_body(r)?;
@@ -153,7 +153,7 @@ impl<T: Atom> DecodeAtom for T {
 }
 
 impl<T: Atom> ReadAtom for T {
-    fn read_atom<R: Read>(header: &Header, r: &mut R) -> Result<Self> {
+    fn read_atom<R: Read + ?Sized>(header: &Header, r: &mut R) -> Result<Self> {
         if header.kind != T::KIND {
             return Err(Error::UnexpectedBox(header.kind));
         }

--- a/src/header.rs
+++ b/src/header.rs
@@ -70,13 +70,13 @@ impl DecodeMaybe for Header {
 }
 
 impl ReadFrom for Header {
-    fn read_from<R: Read>(r: &mut R) -> Result<Self> {
+    fn read_from<R: Read + ?Sized>(r: &mut R) -> Result<Self> {
         <Option<Header> as ReadFrom>::read_from(r)?.ok_or(Error::UnexpectedEof)
     }
 }
 
 impl ReadFrom for Option<Header> {
-    fn read_from<R: Read>(r: &mut R) -> Result<Self> {
+    fn read_from<R: Read + ?Sized>(r: &mut R) -> Result<Self> {
         let mut buf = [0u8; 8];
         let n = r.read(&mut buf)?;
         if n == 0 {
@@ -107,7 +107,7 @@ impl ReadFrom for Option<Header> {
 
 // Utility methods
 impl Header {
-    pub(crate) fn read_body<R: Read>(&self, r: &mut R) -> Result<Cursor<Vec<u8>>> {
+    pub(crate) fn read_body<R: Read + ?Sized>(&self, r: &mut R) -> Result<Cursor<Vec<u8>>> {
         // TODO This allocates on the heap.
         // Ideally, we should use ReadFrom instead of Decode to avoid this.
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -132,7 +132,7 @@ impl Header {
     }
 
     #[cfg(feature = "tokio")]
-    pub(crate) async fn read_body_tokio<R: ::tokio::io::AsyncRead + Unpin>(
+    pub(crate) async fn read_body_tokio<R: ::tokio::io::AsyncRead + Unpin + ?Sized>(
         &self,
         r: &mut R,
     ) -> Result<Cursor<Vec<u8>>> {

--- a/src/io.rs
+++ b/src/io.rs
@@ -19,11 +19,11 @@ pub trait ReadUntil: Sized {
 
 /// Write a type to a writer.
 pub trait WriteTo {
-    fn write_to<W: Write>(&self, w: &mut W) -> Result<()>;
+    fn write_to<W: Write + ?Sized>(&self, w: &mut W) -> Result<()>;
 }
 
 impl<T: Encode> WriteTo for T {
-    fn write_to<W: Write>(&self, w: &mut W) -> Result<()> {
+    fn write_to<W: Write + ?Sized>(&self, w: &mut W) -> Result<()> {
         // TODO We should avoid allocating a buffer here.
         let mut buf = Vec::new();
         self.encode(&mut buf)?;

--- a/src/io.rs
+++ b/src/io.rs
@@ -4,17 +4,17 @@ use super::*;
 
 /// Read a type from a reader.
 pub trait ReadFrom: Sized {
-    fn read_from<R: Read>(r: &mut R) -> Result<Self>;
+    fn read_from<R: Read + ?Sized>(r: &mut R) -> Result<Self>;
 }
 
 /// Read an atom from a reader provided the header.
 pub trait ReadAtom: Sized {
-    fn read_atom<R: Read>(header: &Header, r: &mut R) -> Result<Self>;
+    fn read_atom<R: Read + ?Sized>(header: &Header, r: &mut R) -> Result<Self>;
 }
 
 /// Keep discarding atoms until the desired atom is found.
 pub trait ReadUntil: Sized {
-    fn read_until<R: Read>(r: &mut R) -> Result<Self>;
+    fn read_until<R: Read + ?Sized>(r: &mut R) -> Result<Self>;
 }
 
 /// Write a type to a writer.

--- a/src/tokio/any.rs
+++ b/src/tokio/any.rs
@@ -5,7 +5,7 @@ use crate::{Any, DecodeAtom, Error, Header, Result};
 use tokio::io::AsyncRead;
 
 impl AsyncReadFrom for Any {
-    async fn read_from<R: AsyncRead + Unpin>(r: &mut R) -> Result<Self> {
+    async fn read_from<R: AsyncRead + Unpin + ?Sized>(r: &mut R) -> Result<Self> {
         <Option<Any> as AsyncReadFrom>::read_from(r)
             .await?
             .ok_or(Error::UnexpectedEof)
@@ -13,7 +13,7 @@ impl AsyncReadFrom for Any {
 }
 
 impl AsyncReadFrom for Option<Any> {
-    async fn read_from<R: AsyncRead + Unpin>(r: &mut R) -> Result<Self> {
+    async fn read_from<R: AsyncRead + Unpin + ?Sized>(r: &mut R) -> Result<Self> {
         let header = match Option::<Header>::read_from(r).await? {
             Some(header) => header,
             None => return Ok(None),
@@ -24,7 +24,7 @@ impl AsyncReadFrom for Option<Any> {
 }
 
 impl AsyncReadAtom for Any {
-    async fn read_atom<R: AsyncRead + Unpin>(header: &Header, r: &mut R) -> Result<Self> {
+    async fn read_atom<R: AsyncRead + Unpin + ?Sized>(header: &Header, r: &mut R) -> Result<Self> {
         let mut buf = header.read_body_tokio(r).await?;
         Any::decode_atom(header, &mut buf)
     }

--- a/src/tokio/atom.rs
+++ b/src/tokio/atom.rs
@@ -5,7 +5,7 @@ use crate::{Atom, Buf, DecodeAtom, Encode, Error, Header, Result};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 
 impl<T: Encode> AsyncWriteTo for T {
-    async fn write_to<W: AsyncWrite + Unpin>(&self, w: &mut W) -> Result<()> {
+    async fn write_to<W: AsyncWrite + Unpin + ?Sized>(&self, w: &mut W) -> Result<()> {
         // TODO We should avoid allocating a buffer here.
         let mut buf = Vec::new();
         self.encode(&mut buf)?;
@@ -14,7 +14,7 @@ impl<T: Encode> AsyncWriteTo for T {
 }
 
 impl<T: Atom> AsyncReadFrom for T {
-    async fn read_from<R: AsyncRead + Unpin>(r: &mut R) -> Result<Self> {
+    async fn read_from<R: AsyncRead + Unpin + ?Sized>(r: &mut R) -> Result<Self> {
         <Option<T> as AsyncReadFrom>::read_from(r)
             .await?
             .ok_or(Error::MissingBox(T::KIND))
@@ -22,7 +22,7 @@ impl<T: Atom> AsyncReadFrom for T {
 }
 
 impl<T: Atom> AsyncReadFrom for Option<T> {
-    async fn read_from<R: AsyncRead + Unpin>(r: &mut R) -> Result<Self> {
+    async fn read_from<R: AsyncRead + Unpin + ?Sized>(r: &mut R) -> Result<Self> {
         let header = match Option::<Header>::read_from(r).await? {
             Some(header) => header,
             None => return Ok(None),
@@ -46,7 +46,7 @@ impl<T: Atom> AsyncReadFrom for Option<T> {
 }
 
 impl<T: Atom> AsyncReadUntil for T {
-    async fn read_until<R: AsyncRead + Unpin>(r: &mut R) -> Result<Self> {
+    async fn read_until<R: AsyncRead + Unpin + ?Sized>(r: &mut R) -> Result<Self> {
         Option::<T>::read_until(r)
             .await?
             .ok_or(Error::MissingBox(T::KIND))
@@ -54,7 +54,7 @@ impl<T: Atom> AsyncReadUntil for T {
 }
 
 impl<T: Atom> AsyncReadUntil for Option<T> {
-    async fn read_until<R: AsyncRead + Unpin>(r: &mut R) -> Result<Self> {
+    async fn read_until<R: AsyncRead + Unpin + ?Sized>(r: &mut R) -> Result<Self> {
         while let Some(header) = Option::<Header>::read_from(r).await? {
             if header.kind == T::KIND {
                 let mut buf = header.read_body_tokio(r).await?;
@@ -67,7 +67,7 @@ impl<T: Atom> AsyncReadUntil for Option<T> {
 }
 
 impl<T: Atom> AsyncReadAtom for T {
-    async fn read_atom<R: AsyncRead + Unpin>(header: &Header, r: &mut R) -> Result<Self> {
+    async fn read_atom<R: AsyncRead + Unpin + ?Sized>(header: &Header, r: &mut R) -> Result<Self> {
         if header.kind != T::KIND {
             return Err(Error::UnexpectedBox(header.kind));
         }

--- a/src/tokio/header.rs
+++ b/src/tokio/header.rs
@@ -5,7 +5,7 @@ use super::*;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 impl AsyncReadFrom for Header {
-    async fn read_from<R: AsyncRead + Unpin>(r: &mut R) -> Result<Self> {
+    async fn read_from<R: AsyncRead + Unpin + ?Sized>(r: &mut R) -> Result<Self> {
         <Option<Header> as AsyncReadFrom>::read_from(r)
             .await?
             .ok_or(Error::UnexpectedEof)
@@ -13,7 +13,7 @@ impl AsyncReadFrom for Header {
 }
 
 impl AsyncReadFrom for Option<Header> {
-    async fn read_from<R: AsyncRead + Unpin>(r: &mut R) -> Result<Self> {
+    async fn read_from<R: AsyncRead + Unpin + ?Sized>(r: &mut R) -> Result<Self> {
         let mut buf = [0u8; 8];
         let n = r.read(&mut buf).await?;
         if n == 0 {

--- a/src/tokio/mod.rs
+++ b/src/tokio/mod.rs
@@ -18,8 +18,10 @@ pub trait AsyncWriteTo {
 
 pub trait AsyncReadAtom: Sized {
     #[allow(async_fn_in_trait)]
-    async fn read_atom<R: tokio::io::AsyncRead + Unpin + ?Sized>(header: &Header, r: &mut R)
-        -> Result<Self>;
+    async fn read_atom<R: tokio::io::AsyncRead + Unpin + ?Sized>(
+        header: &Header,
+        r: &mut R,
+    ) -> Result<Self>;
 }
 
 pub trait AsyncReadUntil: Sized {

--- a/src/tokio/mod.rs
+++ b/src/tokio/mod.rs
@@ -8,21 +8,21 @@ use crate::{Header, Result};
 
 pub trait AsyncReadFrom: Sized {
     #[allow(async_fn_in_trait)]
-    async fn read_from<R: tokio::io::AsyncRead + Unpin>(r: &mut R) -> Result<Self>;
+    async fn read_from<R: tokio::io::AsyncRead + Unpin + ?Sized>(r: &mut R) -> Result<Self>;
 }
 
 pub trait AsyncWriteTo {
     #[allow(async_fn_in_trait)]
-    async fn write_to<W: tokio::io::AsyncWrite + Unpin>(&self, w: &mut W) -> Result<()>;
+    async fn write_to<W: tokio::io::AsyncWrite + Unpin + ?Sized>(&self, w: &mut W) -> Result<()>;
 }
 
 pub trait AsyncReadAtom: Sized {
     #[allow(async_fn_in_trait)]
-    async fn read_atom<R: tokio::io::AsyncRead + Unpin>(header: &Header, r: &mut R)
+    async fn read_atom<R: tokio::io::AsyncRead + Unpin + ?Sized>(header: &Header, r: &mut R)
         -> Result<Self>;
 }
 
 pub trait AsyncReadUntil: Sized {
     #[allow(async_fn_in_trait)]
-    async fn read_until<R: tokio::io::AsyncRead + Unpin>(r: &mut R) -> Result<Self>;
+    async fn read_until<R: tokio::io::AsyncRead + Unpin + ?Sized>(r: &mut R) -> Result<Self>;
 }


### PR DESCRIPTION
Adding ?Sized allows the traits to work with unsized types (e.g. dyn Read).