### PR TITLE
Expose flags on Tkhd

### DIFF
--- a/src/moov/mod.rs
+++ b/src/moov/mod.rs
@@ -148,6 +148,8 @@ mod test {
                         modification_time: 3773812694,
                         track_id: 1,
                         enabled: true,
+                        in_movie: true,
+                        in_preview: true,
                         width: 1920.into(),
                         height: 1080.into(),
                         ..Default::default()

--- a/src/moov/mod.rs
+++ b/src/moov/mod.rs
@@ -148,6 +148,7 @@ mod test {
                         modification_time: 3773812694,
                         track_id: 1,
                         enabled: true,
+                        in_movie: true,
                         width: 1920.into(),
                         height: 1080.into(),
                         ..Default::default()

--- a/src/moov/trak/tkhd.rs
+++ b/src/moov/trak/tkhd.rs
@@ -20,6 +20,8 @@ pub struct Tkhd {
     pub layer: u16,
     pub alternate_group: u16,
     pub enabled: bool,
+    pub in_movie: bool,
+    pub in_preview: bool,
 
     pub volume: FixedPoint<u8>,
     pub matrix: Matrix,
@@ -73,6 +75,8 @@ impl AtomExt for Tkhd {
             width,
             height,
             enabled: ext.track_enabled,
+            in_movie: ext.track_in_movie,
+            in_preview: ext.track_in_preview,
         })
     }
 
@@ -96,7 +100,8 @@ impl AtomExt for Tkhd {
         Ok(TkhdExt {
             version: TkhdVersion::V1,
             track_enabled: self.enabled,
-            ..Default::default()
+            track_in_movie: self.in_movie,
+            track_in_preview: self.in_preview,
         })
     }
 }
@@ -190,6 +195,8 @@ mod tests {
             width: 512.into(),
             height: 288.into(),
             enabled: true,
+            in_movie: true,
+            in_preview: false,
         };
         let mut buf = Vec::new();
         expected.encode(&mut buf).unwrap();
@@ -213,6 +220,8 @@ mod tests {
             width: 512.into(),
             height: 288.into(),
             enabled: true,
+            in_movie: true,
+            in_preview: false,
         };
         let mut buf = Vec::new();
         expected.encode(&mut buf).unwrap();

--- a/src/moov/trak/tkhd.rs
+++ b/src/moov/trak/tkhd.rs
@@ -7,6 +7,7 @@ ext! {
         track_enabled = 0,
         track_in_movie = 1,
         track_in_preview = 2,
+        track_size_is_aspect_ratio = 3,
     }
 }
 
@@ -20,6 +21,10 @@ pub struct Tkhd {
     pub layer: u16,
     pub alternate_group: u16,
     pub enabled: bool,
+    pub in_movie: bool,
+    /// When set, `width`/`height` express the track's suggested aspect ratio
+    /// rather than pixel dimensions (ISO/IEC 14496-12:2022 §8.3.2.3).
+    pub size_is_aspect_ratio: bool,
 
     pub volume: FixedPoint<u8>,
     pub matrix: Matrix,
@@ -73,6 +78,10 @@ impl AtomExt for Tkhd {
             width,
             height,
             enabled: ext.track_enabled,
+            in_movie: ext.track_in_movie,
+            size_is_aspect_ratio: ext.track_size_is_aspect_ratio,
+            // track_in_preview has no assigned meaning and is ignored on read
+            // per ISO/IEC 14496-12:2022 §8.3.2.3.
         })
     }
 
@@ -96,7 +105,11 @@ impl AtomExt for Tkhd {
         Ok(TkhdExt {
             version: TkhdVersion::V1,
             track_enabled: self.enabled,
-            ..Default::default()
+            track_in_movie: self.in_movie,
+            // track_in_preview has no assigned meaning; per ISO/IEC
+            // 14496-12:2022 §8.3.2.3 writers should mirror track_in_movie.
+            track_in_preview: self.in_movie,
+            track_size_is_aspect_ratio: self.size_is_aspect_ratio,
         })
     }
 }
@@ -190,6 +203,8 @@ mod tests {
             width: 512.into(),
             height: 288.into(),
             enabled: true,
+            in_movie: true,
+            size_is_aspect_ratio: false,
         };
         let mut buf = Vec::new();
         expected.encode(&mut buf).unwrap();
@@ -213,6 +228,8 @@ mod tests {
             width: 512.into(),
             height: 288.into(),
             enabled: true,
+            in_movie: true,
+            size_is_aspect_ratio: false,
         };
         let mut buf = Vec::new();
         expected.encode(&mut buf).unwrap();

--- a/src/test/av1.rs
+++ b/src/test/av1.rs
@@ -64,6 +64,8 @@ fn av1() {
                     layer: 0,
                     alternate_group: 0,
                     enabled: true,
+                    in_movie: true,
+                    in_preview: false,
                     volume: 0.into(),
                     matrix: Matrix {
                         a: 65536,

--- a/src/test/av1.rs
+++ b/src/test/av1.rs
@@ -64,6 +64,8 @@ fn av1() {
                     layer: 0,
                     alternate_group: 0,
                     enabled: true,
+                    in_movie: true,
+                    size_is_aspect_ratio: false,
                     volume: 0.into(),
                     matrix: Matrix {
                         a: 65536,

--- a/src/test/bbb.rs
+++ b/src/test/bbb.rs
@@ -47,6 +47,8 @@ fn bbb() {
                 tkhd: Tkhd {
                     track_id: 1,
                     enabled: true,
+                    in_movie: true,
+                    in_preview: false,
                     width: 1280.into(),
                     height: 720.into(),
                     ..Default::default()
@@ -129,6 +131,8 @@ fn bbb() {
                     track_id: 2,
                     alternate_group: 1,
                     enabled: true,
+                    in_movie: true,
+                    in_preview: false,
                     volume: 1.into(),
                     ..Default::default()
                 },

--- a/src/test/bbb.rs
+++ b/src/test/bbb.rs
@@ -47,6 +47,7 @@ fn bbb() {
                 tkhd: Tkhd {
                     track_id: 1,
                     enabled: true,
+                    in_movie: true,
                     width: 1280.into(),
                     height: 720.into(),
                     ..Default::default()
@@ -129,6 +130,7 @@ fn bbb() {
                     track_id: 2,
                     alternate_group: 1,
                     enabled: true,
+                    in_movie: true,
                     volume: 1.into(),
                     ..Default::default()
                 },

--- a/src/test/esds.rs
+++ b/src/test/esds.rs
@@ -47,6 +47,8 @@ fn esds() {
                 tkhd: Tkhd {
                     track_id: 1,
                     enabled: true,
+                    in_movie: true,
+                    in_preview: false,
                     width: 1280.into(),
                     height: 720.into(),
                     ..Default::default()
@@ -129,6 +131,8 @@ fn esds() {
                     track_id: 2,
                     alternate_group: 1,
                     enabled: true,
+                    in_movie: true,
+                    in_preview: false,
                     volume: 1.into(),
                     ..Default::default()
                 },

--- a/src/test/esds.rs
+++ b/src/test/esds.rs
@@ -47,6 +47,7 @@ fn esds() {
                 tkhd: Tkhd {
                     track_id: 1,
                     enabled: true,
+                    in_movie: true,
                     width: 1280.into(),
                     height: 720.into(),
                     ..Default::default()
@@ -129,6 +130,7 @@ fn esds() {
                     track_id: 2,
                     alternate_group: 1,
                     enabled: true,
+                    in_movie: true,
                     volume: 1.into(),
                     ..Default::default()
                 },

--- a/src/test/flac.rs
+++ b/src/test/flac.rs
@@ -60,6 +60,8 @@ fn flac() {
                     layer: 0,
                     alternate_group: 0,
                     enabled: true,
+                    in_movie: true,
+                    in_preview: true,
                     volume: 1.into(),
                     matrix: Matrix {
                         a: 65536,

--- a/src/test/flac.rs
+++ b/src/test/flac.rs
@@ -60,6 +60,8 @@ fn flac() {
                     layer: 0,
                     alternate_group: 0,
                     enabled: true,
+                    in_movie: true,
+                    size_is_aspect_ratio: false,
                     volume: 1.into(),
                     matrix: Matrix {
                         a: 65536,

--- a/src/test/h264.rs
+++ b/src/test/h264.rs
@@ -69,6 +69,8 @@ fn avcc_ext() {
                     layer: 0,
                     alternate_group: 0,
                     enabled: true,
+                    in_movie: true,
+                    in_preview: false,
                     volume: 0.into(),
                     matrix: Matrix {
                         a: 65536,
@@ -189,6 +191,8 @@ fn avcc_ext() {
                     layer: 0,
                     alternate_group: 1,
                     enabled: true,
+                    in_movie: true,
+                    in_preview: false,
                     volume: 1.into(),
                     matrix: Matrix {
                         a: 65536,

--- a/src/test/h264.rs
+++ b/src/test/h264.rs
@@ -69,6 +69,8 @@ fn avcc_ext() {
                     layer: 0,
                     alternate_group: 0,
                     enabled: true,
+                    in_movie: true,
+                    size_is_aspect_ratio: false,
                     volume: 0.into(),
                     matrix: Matrix {
                         a: 65536,
@@ -189,6 +191,8 @@ fn avcc_ext() {
                     layer: 0,
                     alternate_group: 1,
                     enabled: true,
+                    in_movie: true,
+                    size_is_aspect_ratio: false,
                     volume: 1.into(),
                     matrix: Matrix {
                         a: 65536,

--- a/src/test/hevc.rs
+++ b/src/test/hevc.rs
@@ -59,6 +59,8 @@ fn hevc() {
                     layer: 0,
                     alternate_group: 0,
                     enabled: true,
+                    in_movie: true,
+                    in_preview: false,
                     volume: 0.into(),
                     matrix: Matrix {
                         a: 65536,

--- a/src/test/hevc.rs
+++ b/src/test/hevc.rs
@@ -59,6 +59,8 @@ fn hevc() {
                     layer: 0,
                     alternate_group: 0,
                     enabled: true,
+                    in_movie: true,
+                    size_is_aspect_ratio: false,
                     volume: 0.into(),
                     matrix: Matrix {
                         a: 65536,

--- a/src/test/libavif_anim.rs
+++ b/src/test/libavif_anim.rs
@@ -160,6 +160,8 @@ fn av1_anim() {
                     layer: 0,
                     alternate_group: 0,
                     enabled: true,
+                    in_movie: false,
+                    in_preview: false,
                     volume: 0.into(),
                     matrix: Matrix {
                         a: 65536,

--- a/src/test/libavif_anim.rs
+++ b/src/test/libavif_anim.rs
@@ -160,6 +160,8 @@ fn av1_anim() {
                     layer: 0,
                     alternate_group: 0,
                     enabled: true,
+                    in_movie: false,
+                    size_is_aspect_ratio: false,
                     volume: 0.into(),
                     matrix: Matrix {
                         a: 65536,

--- a/src/test/uncompressed.rs
+++ b/src/test/uncompressed.rs
@@ -53,6 +53,8 @@ fn uncompressed() {
                     layer: 0,
                     alternate_group: 0,
                     enabled: true,
+                    in_movie: true,
+                    in_preview: true,
                     volume: 0.into(),
                     matrix: Matrix {
                         a: 65536,

--- a/src/test/uncompressed.rs
+++ b/src/test/uncompressed.rs
@@ -53,6 +53,8 @@ fn uncompressed() {
                     layer: 0,
                     alternate_group: 0,
                     enabled: true,
+                    in_movie: true,
+                    size_is_aspect_ratio: false,
                     volume: 0.into(),
                     matrix: Matrix {
                         a: 65536,

--- a/src/test/vp9.rs
+++ b/src/test/vp9.rs
@@ -84,6 +84,8 @@ fn vp9() {
                     layer: 0,
                     alternate_group: 0,
                     enabled: true,
+                    in_movie: true,
+                    in_preview: true,
                     volume: 0.into(),
                     matrix: Matrix {
                         a: 65536,

--- a/src/test/vp9.rs
+++ b/src/test/vp9.rs
@@ -84,6 +84,8 @@ fn vp9() {
                     layer: 0,
                     alternate_group: 0,
                     enabled: true,
+                    in_movie: true,
+                    size_is_aspect_ratio: false,
                     volume: 0.into(),
                     matrix: Matrix {
                         a: 65536,


### PR DESCRIPTION
Ran into this while working on the MUXL spec; I think having `track_in_movie` set is probably a sensible default. Now we can do that!

From Claude:

> The tkhd box has three flag bits: track_enabled (bit 0), track_in_movie (bit 1), and track_in_preview (bit 2). Previously only track_enabled was exposed as a public field. The other two were decoded but discarded, and always written as false on encode.

> Add `in_movie` and `in_preview` fields to Tkhd so callers can read and write all three flags. Update all test expectations to match the actual flag values in their respective fixtures.