### PR TITLE
Fix dref url self_contained flag bit position

### DIFF
--- a/src/moov/trak/mdia/minf/dinf/dref/url.rs
+++ b/src/moov/trak/mdia/minf/dinf/dref/url.rs
@@ -4,7 +4,7 @@ ext! {
     name: Url,
     versions: [0],
     flags: {
-        self_contained = 1,
+        self_contained = 0,
     }
 }
 
@@ -34,7 +34,7 @@ impl AtomExt for Url {
         }
 
         Ok(UrlExt {
-            // TODO what does this do?
+            // ISOBMFF §8.7.2: flag bit 0 = media data is in the same file
             self_contained: true,
             ..Default::default()
         })


### PR DESCRIPTION
Noticed that this library was setting 0x000002 on the `url ` box and couldn't figure out why; Claude figured out it was a bug. Neat.

From Claude:

> The self_contained flag in the url box should be bit 0 (0x000001) per ISOBMFF §8.7.2, but was defined at bit index 1, producing flags=0x000002. This could cause strict parsers to interpret the data reference as non-self-contained.