### PR TITLE
flac/avcc: bound Vec::with_capacity in parse_vorbis_comment and Avcc

### DIFF
--- a/src/moov/trak/mdia/minf/stbl/stsd/flac.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/flac.rs
@@ -186,7 +186,12 @@ fn parse_vorbis_comment(arr: &[u8]) -> Result<FlacMetadataBlock> {
         .trim_end_matches('\0')
         .to_string();
     let number_of_fields = u32::from_le_bytes(<[u8; 4]>::decode(buf)?) as usize;
-    let mut comments = Vec::with_capacity(number_of_fields);
+    // Each field is at least 4 bytes (the field_length u32); reject counts
+    // that cannot possibly fit in the remaining buffer before allocating.
+    if number_of_fields > buf.remaining() / 4 {
+        return Err(Error::OutOfBounds);
+    }
+    let mut comments = Vec::with_capacity(number_of_fields.min(4096));
     for _ in 0..number_of_fields {
         let field_length = u32::from_le_bytes(<[u8; 4]>::decode(buf)?) as usize;
         let field_bytes: Vec<u8> = Vec::decode_exact(buf, field_length)?;
@@ -349,6 +354,24 @@ mod tests {
                 ]
             }
         );
+    }
+
+    // Regression for issue #154: a u32::MAX number_of_fields must
+    // fail cleanly without attempting a ~103 GiB upfront allocation.
+    const ENCODED_DFLA_VORBIS_HUGE_COUNT: &[u8] = &[
+        // VorbisComment block: is_last=1, block_type=4, length=8
+        0x84, 0x00, 0x00, 0x08, // vendor_string_length = 0 (LE)
+        0x00, 0x00, 0x00, 0x00, // number_of_fields = u32::MAX (LE)
+        0xFF, 0xFF, 0xFF, 0xFF,
+    ];
+
+    #[test]
+    fn test_dfla_vorbis_huge_count() {
+        let buf = &mut std::io::Cursor::new(ENCODED_DFLA_VORBIS_HUGE_COUNT);
+        assert!(matches!(
+            Dfla::decode_body_ext(buf, ()),
+            Err(Error::OutOfBounds)
+        ));
     }
 
     #[test]

--- a/src/moov/trak/mdia/minf/stbl/stsd/flac.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/flac.rs
@@ -150,8 +150,8 @@ pub struct Dfla {
     pub blocks: Vec<FlacMetadataBlock>,
 }
 
+/// Parse a FLAC `StreamInfo` metadata block. See RFC 9639 Section 8.2.
 fn parse_stream_info(arr: &[u8]) -> Result<FlacMetadataBlock> {
-    // See RFC 9639 Section 8.2
     let buf = &mut std::io::Cursor::new(arr);
     let minimum_block_size = u16::decode(buf)?;
     let maximum_block_size = u16::decode(buf)?;
@@ -176,9 +176,10 @@ fn parse_stream_info(arr: &[u8]) -> Result<FlacMetadataBlock> {
     })
 }
 
+/// Parse a FLAC `VorbisComment` metadata block. See RFC 9639 Section 8.6
+/// (D.2.5 has an example). Vorbis comments in FLAC use little-endian
+/// integers for Vorbis compatibility.
 fn parse_vorbis_comment(arr: &[u8]) -> Result<FlacMetadataBlock> {
-    // See RFC 9639 Section 8.6, and D.2.5 for an example
-    // Vorbis comments in FLAC use little endian, for Vorbis compatibility
     let buf = &mut std::io::Cursor::new(arr);
     let vendor_string_length = u32::from_le_bytes(<[u8; 4]>::decode(buf)?) as usize;
     let vendor_string_bytes: Vec<u8> = Vec::decode_exact(buf, vendor_string_length)?;

--- a/src/moov/trak/mdia/minf/stbl/stsd/h264/avcc.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/h264/avcc.rs
@@ -94,7 +94,7 @@ impl Atom for Avcc {
             let bit_depth_chroma_minus8 = u8::decode(buf)? & 0x7;
             let num_of_sequence_parameter_set_exts = u8::decode(buf)? as usize;
             let mut sequence_parameter_sets_ext =
-                Vec::with_capacity(num_of_sequence_parameter_set_exts);
+                Vec::with_capacity(num_of_sequence_parameter_set_exts.min(4096));
 
             for _ in 0..num_of_sequence_parameter_set_exts {
                 let size = u16::decode(buf)? as usize;

--- a/src/moov/trak/mdia/minf/stbl/stsd/h264/avcc.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/h264/avcc.rs
@@ -94,7 +94,7 @@ impl Atom for Avcc {
             let bit_depth_chroma_minus8 = u8::decode(buf)? & 0x7;
             let num_of_sequence_parameter_set_exts = u8::decode(buf)? as usize;
             let mut sequence_parameter_sets_ext =
-                Vec::with_capacity(num_of_sequence_parameter_set_exts.min(4096));
+                Vec::with_capacity(num_of_sequence_parameter_set_exts);
 
             for _ in 0..num_of_sequence_parameter_set_exts {
                 let size = u16::decode(buf)? as usize;


### PR DESCRIPTION
Closes #154.

`parse_vorbis_comment` (`src/moov/trak/mdia/minf/stbl/stsd/flac.rs`) gets:

- A pre-flight rejecting `number_of_fields` counts that can't fit in the remaining buffer. Each field carries a u32 length prefix, so anything past `buf.remaining() / 4` is structurally impossible. Returns `Error::OutOfBounds`. Same defensive idiom as `header.rs:114-117` and `trun.rs:50-60` - refuse impossible claims before allocating.
- `Vec::with_capacity` capped at 4096, matching `trun.rs:61`.

~~`Avcc` (`src/moov/trak/mdia/minf/stbl/stsd/h264/avcc.rs:97`) gets the same `min(4096)` cap. The source is a `u8` so it's a no-op in practice; included for crate-wide consistency.~~

Regression test pins `Err(Error::OutOfBounds)` via `matches!`, so it fails if the pre-flight ever regresses.

Three adjacent sites have the same shape and lack guards: `saiz.rs:54` (u32 count, 1 byte/entry, the most exposed), `saiz.rs:118` (u32, 4-8 bytes), `hvcc.rs:75` (u16, 2 bytes). Tracked as #156, scoped separately to keep this PR focused on #154.

Second commit hoists the existing inline `// See RFC 9639...` comments onto `parse_stream_info` and `parse_vorbis_comment` as proper `///` docstrings (no new prose, just relocation). Addresses CodeRabbit's docstring-coverage warning.

## Test plan

- [x] `cargo test --all-features` (207 pass, including new regression)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Original 110-byte fuzz input from #154 now decodes one atom and returns `Err(OverDecode(dfLa))` (which wraps the inner `Err(OutOfBounds)` from the new pre-flight). No OOM. Verified by running the input through `Any::decode_maybe` in a loop.
