### PR TITLE
deps: replace unmaintained `paste` with `pastey`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
  "bytes",
  "derive_more",
  "num",
- "paste",
+ "pastey",
  "serde",
  "thiserror",
  "tokio",
@@ -239,10 +239,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pin-project-lite"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,9 +240,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pastey"
-version = "0.1.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "pin-project-lite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["mp4", "isobmff", "mp4box", "audio", "video"]
 categories = ["multimedia::encoding"]
 
 [dependencies]
-pastey = "0.1"
+pastey = "0.2"
 thiserror = "1"
 num = "0.4"
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["mp4", "isobmff", "mp4box", "audio", "video"]
 categories = ["multimedia::encoding"]
 
 [dependencies]
-paste = "1"
+pastey = "0.1"
 thiserror = "1"
 num = "0.4"
 tracing = "0.1"

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -174,7 +174,7 @@ nested! {
 
 macro_rules! nested {
     (required: [$($required:ident),*$(,)?], optional: [$($optional:ident),*$(,)?], multiple: [$($multiple:ident),*$(,)?],) => {
-        paste::paste! {
+        pastey::paste! {
             fn decode_body<B: Buf>(buf: &mut B) -> Result<Self> {
                 $( let mut [<$required:lower>] = None;)*
                 $( let mut [<$optional:lower>] = None;)*

--- a/src/atom_ext.rs
+++ b/src/atom_ext.rs
@@ -89,7 +89,7 @@ struct TfdtExt {
 
 macro_rules! ext {
     (name: $name:ident, versions: [$($version:expr),*], flags: { $($flag:ident = $bit:expr,)* }) => {
-        paste::paste! {
+        pastey::paste! {
             #[derive(Debug, Clone, Copy, PartialEq, Eq)]
             pub(crate) enum [<$name Version>] {
                 $(


### PR DESCRIPTION
Closes #159.

Swaps `paste` (archived 2024, RUSTSEC-2024-0436) for `pastey`, a maintained drop-in fork. Stops `cargo audit` / `cargo deny` from flagging the dependency for downstream users.

Mechanical change at the two internal call sites:

- `Cargo.toml`: `paste = "1"` -> `pastey = "0.2"`
- `src/atom_ext.rs:92` and `src/atom.rs:177`: `paste::paste!` -> `pastey::paste!`

Both macros (`ext!` and `nested!`) are `pub(crate)`, so the dependency was never part of the public API and the swap doesn't show up in downstream code.

Pinned to `0.2` (latest is 0.2.2).

## Test plan

- [x] `cargo test --all-features` (206 pass + 3 doc-tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt -- --check` clean