### PR TITLE
mp4a: find esds inside the QuickTime wave box

### DIFF
--- a/src/moov/trak/mdia/minf/stbl/stsd/mp4a/mod.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/mp4a/mod.rs
@@ -23,12 +23,17 @@ impl Atom for Mp4a {
         let mut esds = None;
         let mut taic = None;
 
-        // Find esds in mp4a or wave
+        // The `esds` sits directly under `mp4a` (ISO-BMFF) or nested inside a
+        // QuickTime `wave` (siDecompressionParam) box (QTFF) — FFmpeg and many
+        // camera muxers emit the latter for AAC-in-MOV.
         while let Some(atom) = Any::decode_maybe(buf)? {
             match atom {
                 Any::Btrt(atom) => btrt = atom.into(),
                 Any::Esds(atom) => esds = atom.into(),
                 Any::Taic(atom) => taic = atom.into(),
+                Any::Unknown(kind, body) if kind == WAVE => {
+                    decode_wave(&body, &mut esds, &mut btrt)?;
+                }
                 unknown => Self::decode_unknown(&unknown)?,
             }
         }
@@ -49,6 +54,34 @@ impl Atom for Mp4a {
 
         Ok(())
     }
+}
+
+/// QuickTime `wave` (siDecompressionParam) container FourCC.
+const WAVE: FourCC = FourCC::new(b"wave");
+
+/// Scan a QuickTime `wave` box body for the `esds` (and `btrt`) it wraps.
+///
+/// Every other child — the `frma` format box, the nested `mp4a` terminator
+/// stub, the trailing all-zero box — is skipped by size. Those are deliberately
+/// NOT typed-decoded: the nested `mp4a` in particular is a 4-byte stub that is
+/// not a valid audio sample entry, so decoding it as one would fail.
+fn decode_wave(mut wave: &[u8], esds: &mut Option<Esds>, btrt: &mut Option<Btrt>) -> Result<()> {
+    while let Some(header) = Header::decode_maybe(&mut wave)? {
+        // A size-to-end (`None`) or over-long child terminates the scan — the
+        // esds, if present, precedes any such terminator.
+        let size = match header.size {
+            Some(size) if size <= wave.remaining() => size,
+            _ => break,
+        };
+        let mut child = wave.slice(size);
+        if header.kind == Esds::KIND {
+            *esds = Some(Esds::decode_body(&mut child)?);
+        } else if header.kind == Btrt::KIND {
+            *btrt = Some(Btrt::decode_body(&mut child)?);
+        }
+        wave.advance(size);
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -96,6 +129,82 @@ mod tests {
         let mut buf = buf.as_ref();
         let decoded = Mp4a::decode(&mut buf).unwrap();
         assert_eq!(decoded, expected);
+    }
+
+    // Build `[size:u32][fourcc][body]`.
+    fn atom_box(fourcc: &[u8; 4], body: &[u8]) -> Vec<u8> {
+        let mut v = Vec::with_capacity(8 + body.len());
+        v.extend_from_slice(&((8 + body.len()) as u32).to_be_bytes());
+        v.extend_from_slice(fourcc);
+        v.extend_from_slice(body);
+        v
+    }
+
+    // QuickTime (QTFF) `mp4a` sample entry: the AAC `esds` is nested inside a
+    // `wave` (siDecompressionParam) box rather than a direct child of `mp4a`.
+    // FFmpeg and camera muxers (MotionCam, etc.) emit MOV audio this way.
+    #[test]
+    fn test_mp4a_quicktime_wave() {
+        let audio = Audio {
+            data_reference_index: 1,
+            channel_count: 2,
+            sample_size: 16,
+            sample_rate: 48000.into(),
+        };
+        let esds = Esds {
+            es_desc: esds::EsDescriptor {
+                es_id: 2,
+                dec_config: esds::DecoderConfig {
+                    object_type_indication: 0x40,
+                    stream_type: 0x05,
+                    up_stream: 0,
+                    buffer_size_db: Default::default(),
+                    max_bitrate: 67695,
+                    avg_bitrate: 67695,
+                    dec_specific: esds::DecoderSpecific {
+                        profile: 2,
+                        freq_index: 4,
+                        chan_conf: 2,
+                    },
+                },
+                sl_config: esds::SLConfig::default(),
+            },
+        };
+
+        let btrt = Btrt {
+            buffer_size_db: 1,
+            max_bitrate: 2,
+            avg_bitrate: 3,
+        };
+
+        // Encode the pieces the QuickTime layout wraps.
+        let mut audio_bytes = Vec::new();
+        audio.encode(&mut audio_bytes).unwrap();
+        let mut esds_box = Vec::new();
+        esds.encode(&mut esds_box).unwrap();
+        let mut btrt_box = Vec::new();
+        btrt.encode(&mut btrt_box).unwrap();
+
+        // wave { frma('mp4a'), mp4a stub (4 zero bytes — NOT a sample entry),
+        //        esds, btrt, all-zero terminator }
+        let mut wave_body = Vec::new();
+        wave_body.extend_from_slice(&atom_box(b"frma", b"mp4a"));
+        wave_body.extend_from_slice(&atom_box(b"mp4a", &[0, 0, 0, 0]));
+        wave_body.extend_from_slice(&esds_box);
+        wave_body.extend_from_slice(&btrt_box);
+        wave_body.extend_from_slice(&[0, 0, 0, 8, 0, 0, 0, 0]);
+
+        // mp4a { audio-header, wave }
+        let mut mp4a_body = audio_bytes;
+        mp4a_body.extend_from_slice(&atom_box(b"wave", &wave_body));
+        let mp4a = atom_box(b"mp4a", &mp4a_body);
+
+        let mut buf = mp4a.as_slice();
+        let decoded = Mp4a::decode(&mut buf).unwrap();
+        assert_eq!(decoded.audio, audio);
+        assert_eq!(decoded.esds, esds);
+        // A `btrt` nested alongside the esds inside `wave` is hoisted too.
+        assert_eq!(decoded.btrt, Some(btrt));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`Mp4a::decode_body` has a comment saying *"Find esds in mp4a or wave"*, but it never actually descends into the QuickTime `wave` box — it only iterates the direct children of `mp4a`. When the `esds` is nested inside a `wave` (`siDecompressionParam`) box, the loop sees `wave` as an unknown atom, skips it via `decode_unknown`, and then returns `Error::MissingBox(esds)`, failing the whole `moov` decode.

This is a very common layout: FFmpeg's `mov` muxer and many camera apps (e.g. MotionCam) emit AAC-in-MOV with the `esds` inside `wave`:

```
mp4a
  wave                       // siDecompressionParam
    frma  'mp4a'
    mp4a  (4-byte stub)      // NOT a valid AudioSampleEntry
    esds
    0000  (all-zero terminator)
```

Such files currently fail to parse entirely with `missing box: esds`.

## Fix

Descend into the `wave` box and scan its children **by header** for `esds` (and `btrt`), which is what the existing comment already promised. Every other child — `frma`, the nested `mp4a` terminator stub, the trailing zero box — is skipped by size and deliberately **not** typed-decoded: the nested `mp4a` is a 4-byte stub that is not a valid audio sample entry, so decoding it as one would error.

The change is additive and does not affect the ISO-BMFF path (esds as a direct child of `mp4a`). Re-encoding normalises to the ISO layout, as before.

## Test

Adds `test_mp4a_quicktime_wave`, which builds the QuickTime `mp4a → wave → { frma, mp4a-stub, esds, terminator }` layout and asserts `Mp4a::decode` recovers the `esds`. Full suite passes (227 tests).
