### PR TITLE
ilst: dispatch children against the iTunes namespace, add cprt item

### DIFF
--- a/src/meta/ilst/cprt.rs
+++ b/src/meta/ilst/cprt.rs
@@ -36,3 +36,51 @@ impl Atom for Copyright {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Long QuickTime/GPAC style: the value is wrapped in a nested `data` atom.
+    // This is what FFmpeg and iTunes write for the `copyright` key.
+    const ENCODED_CPRT_LONG: &[u8] = &[
+        0x00, 0x00, 0x00, 0x22, // cprt size = 34
+        b'c', b'p', b'r', b't', //
+        0x00, 0x00, 0x00, 0x1A, // data size = 26
+        b'd', b'a', b't', b'a', //
+        0x00, 0x00, 0x00, 0x01, // type indicator: UTF-8
+        0x00, 0x00, 0x00, 0x00, // country + language
+        b'(', b'c', b')', b' ', b'2', b'0', b'2', b'6', b' ', b'x',
+    ];
+
+    #[test]
+    fn test_copyright_long_style() {
+        let decoded = Copyright::decode(&mut &ENCODED_CPRT_LONG[..]).unwrap();
+        assert_eq!(decoded.country_indicator, 0);
+        assert_eq!(decoded.language_indicator, 0);
+        assert_eq!(decoded.text, "(c) 2026 x");
+
+        // The encoder always emits the long `data`-wrapped layout.
+        let mut out = Vec::new();
+        decoded.encode(&mut out).unwrap();
+        assert_eq!(out, ENCODED_CPRT_LONG);
+    }
+
+    // Short FFmpeg style: the UTF-8 value follows the item header directly (no
+    // nested `data` atom); the leading `1` is the type indicator, too small to
+    // be a valid `data` atom length.
+    #[test]
+    fn test_copyright_short_style() {
+        let buf = [
+            0x00, 0x00, 0x00, 0x14, // cprt size = 20
+            b'c', b'p', b'r', b't', //
+            0x00, 0x00, 0x00, 0x01, // type indicator (short style): UTF-8
+            0x00, 0x00, 0x00, 0x00, // country + language
+            b'2', b'0', b'2', b'6',
+        ];
+        let decoded = Copyright::decode(&mut &buf[..]).unwrap();
+        assert_eq!(decoded.country_indicator, 0);
+        assert_eq!(decoded.language_indicator, 0);
+        assert_eq!(decoded.text, "2026");
+    }
+}

--- a/src/meta/ilst/cprt.rs
+++ b/src/meta/ilst/cprt.rs
@@ -1,0 +1,38 @@
+use crate::*;
+
+/// An iTunes-style copyright notice, written by FFmpeg and iTunes for the
+/// `copyright` metadata key.
+///
+/// This lives inside `moov/udta/meta/ilst` and shares its fourcc with the
+/// unrelated ISO CopyrightBox ([`Cprt`]) found directly under `udta` — the
+/// two have completely different layouts. It is deliberately NOT part of the
+/// global [`Any`] dispatch; [`Ilst`] decodes it by header.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Copyright {
+    pub country_indicator: u16,
+    pub language_indicator: u16,
+    pub text: String,
+}
+
+impl Atom for Copyright {
+    const KIND: FourCC = FourCC::new(b"cprt");
+
+    fn decode_body<B: Buf>(buf: &mut B) -> Result<Self> {
+        let data = super::data::decode_text(buf)?;
+        Ok(Copyright {
+            country_indicator: data.country_indicator,
+            language_indicator: data.language_indicator,
+            text: data.text,
+        })
+    }
+
+    fn encode_body<B: BufMut>(&self, buf: &mut B) -> Result<()> {
+        super::data::encode_text(
+            self.country_indicator,
+            self.language_indicator,
+            &self.text,
+            buf,
+        )
+    }
+}

--- a/src/meta/ilst/cprt.rs
+++ b/src/meta/ilst/cprt.rs
@@ -4,7 +4,7 @@ use crate::*;
 /// `copyright` metadata key.
 ///
 /// This lives inside `moov/udta/meta/ilst` and shares its fourcc with the
-/// unrelated ISO CopyrightBox ([`Cprt`]) found directly under `udta` — the
+/// unrelated ISO CopyrightBox ([`cprt`]) found directly under `udta` — the
 /// two have completely different layouts. It is deliberately NOT part of the
 /// global [`Any`] dispatch; [`Ilst`] decodes it by header.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/meta/ilst/data.rs
+++ b/src/meta/ilst/data.rs
@@ -1,0 +1,78 @@
+use crate::*;
+
+pub(crate) const DATA_4CC: FourCC = FourCC::new(b"data");
+const TYPE_INDICATOR_UTF8: u32 = 1u32;
+
+/// A UTF-8 text payload of an iTunes-style `ilst` metadata item.
+///
+/// Two encodings exist in the wild: the FFmpeg "short" style, where the value
+/// follows the item header directly, and the QuickTime/GPAC "long" style,
+/// where the value is wrapped in a nested `data` atom.
+pub(crate) struct DataText {
+    pub country_indicator: u16,
+    pub language_indicator: u16,
+    pub text: String,
+}
+
+pub(crate) fn decode_text<B: Buf>(buf: &mut B) -> Result<DataText> {
+    let type_indicator_or_len = u32::decode(buf)?;
+    match type_indicator_or_len {
+        1 => {
+            // Too short for a valid length, so probably
+            // UTF-8 text, FFmpeg short-style
+            let country_indicator = u16::decode(buf)?;
+            let language_indicator = u16::decode(buf)?;
+            Ok(DataText {
+                country_indicator,
+                language_indicator,
+                text: String::decode(buf)?,
+            })
+        }
+        _ => {
+            // Maybe Atom follows on straight away.
+            // Try parsing as Quicktime data atom: GPAC style or FFmpeg long style
+            let fourcc = FourCC::decode(buf)?;
+            if fourcc != DATA_4CC {
+                return Err(Error::UnexpectedBox(fourcc));
+            }
+            let type_indicator = u32::decode(buf)?;
+            if type_indicator != TYPE_INDICATOR_UTF8 {
+                return Err(Error::Unsupported(
+                    "Only UTF-8 text is supported in ilst data atoms",
+                ));
+            }
+            let country_indicator = u16::decode(buf)?;
+            let language_indicator = u16::decode(buf)?;
+            let remaining_bytes = buf.remaining();
+            let body = &mut buf.slice(remaining_bytes);
+            let text = String::from_utf8(body.to_vec()).map_err(|_| Error::InvalidSize)?;
+            buf.advance(remaining_bytes);
+            Ok(DataText {
+                country_indicator,
+                language_indicator,
+                text,
+            })
+        }
+    }
+}
+
+pub(crate) fn encode_text<B: BufMut>(
+    country_indicator: u16,
+    language_indicator: u16,
+    text: &str,
+    buf: &mut B,
+) -> Result<()> {
+    let text_bytes = text.as_bytes();
+    // the length of the nested atom is the length field (4 bytes),
+    // the 4CC (4 bytes), the type indicator (4 bytes), the country
+    // indicator (2 bytes), the language indicator (2 bytes) and
+    // then the actual text.
+    let nested_len = (4 + 4 + 4 + 2 + 2 + text_bytes.len()) as u32;
+    nested_len.encode(buf)?;
+    DATA_4CC.encode(buf)?;
+    TYPE_INDICATOR_UTF8.encode(buf)?;
+    country_indicator.encode(buf)?;
+    language_indicator.encode(buf)?;
+    text_bytes.encode(buf)?;
+    Ok(())
+}

--- a/src/meta/ilst/data.rs
+++ b/src/meta/ilst/data.rs
@@ -76,3 +76,53 @@ pub(crate) fn encode_text<B: BufMut>(
     text_bytes.encode(buf)?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Long QuickTime/GPAC style: the value is wrapped in a nested `data` atom.
+    // This is the layout `encode_text` always emits.
+    const LONG_STYLE: &[u8] = &[
+        0x00, 0x00, 0x00, 0x1A, // data atom size = 26
+        b'd', b'a', b't', b'a', //
+        0x00, 0x00, 0x00, 0x01, // type indicator: UTF-8
+        0x00, 0x00, 0x00, 0x00, // country + language
+        b'(', b'c', b')', b' ', b'2', b'0', b'2', b'6', b' ', b'x',
+    ];
+
+    #[test]
+    fn test_decode_text_short_style() {
+        // FFmpeg short style: the leading `1` is the type indicator (too small
+        // to be a valid `data` atom length), so the UTF-8 value follows directly.
+        let buf = [
+            0x00, 0x00, 0x00, 0x01, // type indicator (short style): UTF-8
+            0x00, 0x00, 0x00, 0x00, // country + language
+            b'2', b'0', b'2', b'6',
+        ];
+        let decoded = decode_text(&mut &buf[..]).unwrap();
+        assert_eq!(decoded.country_indicator, 0);
+        assert_eq!(decoded.language_indicator, 0);
+        assert_eq!(decoded.text, "2026");
+    }
+
+    #[test]
+    fn test_decode_text_long_style() {
+        let decoded = decode_text(&mut &LONG_STYLE[..]).unwrap();
+        assert_eq!(decoded.country_indicator, 0);
+        assert_eq!(decoded.language_indicator, 0);
+        assert_eq!(decoded.text, "(c) 2026 x");
+    }
+
+    #[test]
+    fn test_encode_text_emits_long_style() {
+        // `encode_text` always emits the long `data`-wrapped layout, which
+        // decodes back to the same value.
+        let mut buf = Vec::new();
+        encode_text(0, 0, "(c) 2026 x", &mut buf).unwrap();
+        assert_eq!(buf, LONG_STYLE);
+
+        let decoded = decode_text(&mut buf.as_slice()).unwrap();
+        assert_eq!(decoded.text, "(c) 2026 x");
+    }
+}

--- a/src/meta/ilst/mod.rs
+++ b/src/meta/ilst/mod.rs
@@ -1,10 +1,13 @@
 mod covr;
+mod cprt;
+mod data;
 mod desc;
 mod name;
 mod tool;
 mod year;
 
 pub use covr::*;
+pub use cprt::*;
 pub use desc::*;
 pub use name::*;
 pub use tool::*;
@@ -19,7 +22,8 @@ pub struct Ilst {
     pub year: Option<Year>, // Called day in the spec
     pub covr: Option<Covr>,
     pub desc: Option<Desc>,
-    pub ctoo: Option<Tool>, // 4CC: "©too"
+    pub ctoo: Option<Tool>,      // 4CC: "©too"
+    pub cprt: Option<Copyright>, // iTunes item, NOT the ISO CopyrightBox
 }
 
 impl Atom for Ilst {
@@ -31,15 +35,32 @@ impl Atom for Ilst {
         let mut covr = None;
         let mut desc = None;
         let mut ctoo = None;
+        let mut cprt = None;
 
-        while let Some(atom) = Any::decode_maybe(buf)? {
-            match atom {
-                Any::Name(atom) => name = atom.into(),
-                Any::Year(atom) => year = atom.into(),
-                Any::Covr(atom) => covr = atom.into(),
-                Any::Desc(atom) => desc = atom.into(),
-                Any::Tool(atom) => ctoo = atom.into(),
-                atom => Self::decode_unknown(&atom)?,
+        // `ilst` children live in the iTunes metadata namespace, which reuses
+        // fourccs of unrelated ISO atoms — an ilst `cprt` item wraps a `data`
+        // atom while the ISO CopyrightBox is a FullBox with a language code.
+        // Dispatch by header against the ilst namespace only, never through
+        // the global `Any` table.
+        while let Some(header) = Header::decode_maybe(buf)? {
+            let size = header.size.unwrap_or(buf.remaining());
+            if size > buf.remaining() {
+                // Truncated child: stop and let the caller's remaining-bytes
+                // check report it, matching `Any::decode_maybe`.
+                break;
+            }
+            match header.kind {
+                Name::KIND => name = Some(Name::decode_atom(&header, buf)?),
+                Year::KIND => year = Some(Year::decode_atom(&header, buf)?),
+                Covr::KIND => covr = Some(Covr::decode_atom(&header, buf)?),
+                Desc::KIND => desc = Some(Desc::decode_atom(&header, buf)?),
+                Tool::KIND => ctoo = Some(Tool::decode_atom(&header, buf)?),
+                Copyright::KIND => cprt = Some(Copyright::decode_atom(&header, buf)?),
+                kind => {
+                    let body = Vec::decode(&mut buf.slice(size))?;
+                    buf.advance(size);
+                    Self::decode_unknown(&Any::Unknown(kind, body))?;
+                }
             }
         }
 
@@ -49,6 +70,7 @@ impl Atom for Ilst {
             covr,
             desc,
             ctoo,
+            cprt,
         })
     }
 
@@ -58,6 +80,7 @@ impl Atom for Ilst {
         self.covr.encode(buf)?;
         self.desc.encode(buf)?;
         self.ctoo.encode(buf)?;
+        self.cprt.encode(buf)?;
         Ok(())
     }
 }
@@ -90,5 +113,65 @@ mod tests {
         let mut buf = buf.as_ref();
         let decoded = Ilst::decode(&mut buf).unwrap();
         assert_eq!(decoded, expected);
+    }
+
+    // Build `[size:u32][fourcc][body]`.
+    fn atom_box(fourcc: &[u8; 4], body: &[u8]) -> Vec<u8> {
+        let mut v = Vec::with_capacity(8 + body.len());
+        v.extend_from_slice(&((8 + body.len()) as u32).to_be_bytes());
+        v.extend_from_slice(fourcc);
+        v.extend_from_slice(body);
+        v
+    }
+
+    // An iTunes `cprt` item (as written by FFmpeg for `-metadata copyright`)
+    // wraps a `data` atom. Pre-fix, Ilst dispatched it through the global
+    // `Any` table where the fourcc collides with the ISO CopyrightBox, so the
+    // whole decode failed with UnderDecode(cprt).
+    #[test]
+    fn test_ilst_itunes_cprt() {
+        let text = b"(c) 2026 Example";
+        let mut data_body = Vec::new();
+        data_body.extend_from_slice(&1u32.to_be_bytes()); // type indicator: UTF-8
+        data_body.extend_from_slice(&0u32.to_be_bytes()); // country + language
+        data_body.extend_from_slice(text);
+        let cprt_item = atom_box(b"cprt", &atom_box(b"data", &data_body));
+        let encoded = atom_box(b"ilst", &cprt_item);
+
+        let decoded = Ilst::decode(&mut encoded.as_slice()).unwrap();
+        assert_eq!(
+            decoded,
+            Ilst {
+                cprt: Some(Copyright {
+                    country_indicator: 0,
+                    language_indicator: 0,
+                    text: "(c) 2026 Example".into(),
+                }),
+                ..Default::default()
+            }
+        );
+
+        // The encoder writes the same long-style `data` layout back.
+        let mut reencoded = Vec::new();
+        decoded.encode(&mut reencoded).unwrap();
+        assert_eq!(reencoded, encoded);
+    }
+
+    // Unknown ilst items still go through decode_unknown (an error in
+    // strict/test builds, a warning otherwise).
+    #[test]
+    fn test_ilst_unknown_item() {
+        let mut data_body = Vec::new();
+        data_body.extend_from_slice(&1u32.to_be_bytes());
+        data_body.extend_from_slice(&0u32.to_be_bytes());
+        data_body.extend_from_slice(b"Some Artist");
+        let art_item = atom_box(b"\xa9ART", &atom_box(b"data", &data_body));
+        let encoded = atom_box(b"ilst", &art_item);
+
+        let result = Ilst::decode(&mut encoded.as_slice());
+        match result {
+            Err(Error::UnexpectedBox(kind)) => assert_eq!(kind, FourCC::new(b"\xa9ART")),
+            other => panic!("expected UnexpectedBox, got {other:?}"),
+        }
     }
 }

--- a/src/meta/ilst/tool.rs
+++ b/src/meta/ilst/tool.rs
@@ -1,8 +1,5 @@
 use crate::*;
 
-const DATA_4CC: FourCC = FourCC::new(b"data");
-const TYPE_INDICATOR_UTF8: u32 = 1u32;
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Tool {
@@ -25,61 +22,21 @@ impl Atom for Tool {
     const KIND: FourCC = FourCC::new(b"\xa9too");
 
     fn decode_body<B: Buf>(buf: &mut B) -> Result<Self> {
-        let type_indicator_or_len = u32::decode(buf)?;
-        match type_indicator_or_len {
-            1 => {
-                // Too short for a valid length, so probably
-                // UTF-8 text, FFmpeg short-style
-                let country_indicator = u16::decode(buf)?;
-                let language_indicator = u16::decode(buf)?;
-                Ok(Tool {
-                    country_indicator,
-                    language_indicator,
-                    text: String::decode(buf)?,
-                })
-            }
-            _ => {
-                // Maybe Atom follows on straight away.
-                // Try parsing as Quicktime data atom: GPAC style or FFmpeg long style
-                let fourcc = FourCC::decode(buf)?;
-                if fourcc != DATA_4CC {
-                    return Err(Error::UnexpectedBox(fourcc));
-                }
-                let type_indicator = u32::decode(buf)?;
-                if type_indicator != TYPE_INDICATOR_UTF8 {
-                    return Err(Error::Unsupported(
-                        "Only UTF-8 text is supported in ilst tool box",
-                    ));
-                }
-                let country_indicator = u16::decode(buf)?;
-                let language_indicator = u16::decode(buf)?;
-                let remaining_bytes = buf.remaining();
-                let body = &mut buf.slice(remaining_bytes);
-                let text = String::from_utf8(body.to_vec()).map_err(|_| Error::InvalidSize)?;
-                buf.advance(remaining_bytes);
-                Ok(Tool {
-                    country_indicator,
-                    language_indicator,
-                    text,
-                })
-            }
-        }
+        let data = super::data::decode_text(buf)?;
+        Ok(Tool {
+            country_indicator: data.country_indicator,
+            language_indicator: data.language_indicator,
+            text: data.text,
+        })
     }
 
     fn encode_body<B: BufMut>(&self, buf: &mut B) -> Result<()> {
-        let text_bytes = self.text.as_bytes();
-        // the length of the nested atom is the length field (4 bytes),
-        // the 4CC (4 bytes), the type indicator (4 bytes), the country
-        // indicator (2 bytes), the language indicator (2 bytes) and
-        // then the actual text.
-        let nested_len = (4 + 4 + 4 + 2 + 2 + text_bytes.len()) as u32;
-        nested_len.encode(buf)?;
-        DATA_4CC.encode(buf)?;
-        TYPE_INDICATOR_UTF8.encode(buf)?;
-        self.country_indicator.encode(buf)?;
-        self.language_indicator.encode(buf)?;
-        text_bytes.encode(buf)?;
-        Ok(())
+        super::data::encode_text(
+            self.country_indicator,
+            self.language_indicator,
+            &self.text,
+            buf,
+        )
     }
 }
 
@@ -154,7 +111,7 @@ mod tests {
         assert!(parse_result.is_err());
         match parse_result.err().unwrap() {
             Error::Unsupported(s) => {
-                assert_eq!(s, "Only UTF-8 text is supported in ilst tool box")
+                assert_eq!(s, "Only UTF-8 text is supported in ilst data atoms")
             }
             _ => {
                 panic!("unexpected error");

--- a/src/test/av1.rs
+++ b/src/test/av1.rs
@@ -180,7 +180,8 @@ fn av1() {
                             country_indicator: 0,
                             language_indicator: 0,
                             text: "Lavf61.7.100".into()
-                        })
+                        }),
+                        cprt: None
                     }
                     .into(),],
                 }),

--- a/src/test/bbb.rs
+++ b/src/test/bbb.rs
@@ -207,7 +207,7 @@ fn bbb() {
             udta: Some(Udta {
                 meta: Some(Meta {
                     hdlr: Hdlr{ handler: FourCC::new(b"mdir"), name: "".into() },
-                    items: vec![Ilst { name: None, year: None, covr: None, desc: None, ctoo: Some(Tool { country_indicator: 0, language_indicator: 0, text: "Lavf61.1.100".into()}) }.into(),],
+                    items: vec![Ilst { name: None, year: None, covr: None, desc: None, ctoo: Some(Tool { country_indicator: 0, language_indicator: 0, text: "Lavf61.1.100".into()}), cprt: None }.into(),],
                 }),
                 ..Default::default()
             }),

--- a/src/test/hevc.rs
+++ b/src/test/hevc.rs
@@ -398,7 +398,8 @@ fn hevc() {
                             country_indicator: 0,
                             language_indicator: 0,
                             text: "Lavf61.7.100".into()
-                        })
+                        }),
+                        cprt: None
                     }
                     .into(),],
                 }),

--- a/src/test/uncompressed.rs
+++ b/src/test/uncompressed.rs
@@ -232,7 +232,8 @@ fn uncompressed() {
                             country_indicator: 0,
                             language_indicator: 0,
                             text: "GPAC-2.5-DEV-rev2076-gd245ba575-rawff_amd2_2024-07-06".into()
-                        })
+                        }),
+                        cprt: None
                     }
                     .into(),],
                 }),


### PR DESCRIPTION
## Problem

iTunes-style `ilst` metadata items reuse fourccs of unrelated ISO atoms. FFmpeg writes `-metadata copyright=...` as an `ilst` `cprt` item wrapping a `data` atom:

```text
udta
  meta
    ilst
      ©nam / ©ART / ©cmt ...   (iTunes text items)
      cprt
        data   (type=1 UTF-8, locale, copyright text)
```

but `Ilst::decode_body` dispatched children through the global `Any` table, where `cprt` is the ISO CopyrightBox (a FullBox with a packed language code). The iTunes item was misparsed as that FullBox, left trailing bytes, and the whole `moov` decode failed with `UnderDecode(cprt)` — so any MP4 tagged with a copyright string (a very common phone-app/FFmpeg output; hit on a real-world H.264+AAC phone clip whose `ilst` is `©nam ©ART aART ©alb ©too ©cmt cprt`) refuses to open.

## Fix

- `Ilst::decode_body` now scans children by header and dispatches against the ilst namespace only, never through the global `Any` table — same approach as the `wave` descent in #170. Unknown ilst items still go through `decode_unknown` (warn by default, error under `strict`), so behavior for them is unchanged.
- The copyright item is typed as a new `Copyright` atom (`Ilst::cprt`). It is deliberately NOT in the `Any` table — the `cprt` fourcc there belongs to the ISO CopyrightBox.
- `Copyright` and `Tool` (`©too`) share the same wire format (FFmpeg short-style vs QuickTime/GPAC `data`-atom long-style), so the codec is factored out into `meta/ilst/data.rs` and both delegate to it. The `Unsupported` message loses its `©too`-specific wording.

## Tests

- `test_ilst_itunes_cprt` — decodes an ilst with a real-world-shaped `cprt` item (pre-fix: `UnderDecode(cprt)`) and round-trips it byte-identically.
- `test_ilst_unknown_item` — pins that unknown ilst items (`©ART`) still route through `decode_unknown`.
- Existing corpus tests updated for the new `Ilst::cprt` field; full suite (229) passes, clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)