### PR TITLE
Add mp4v sample entry and decode QuickTime v2 sound descriptions

### DIFF
--- a/src/any.rs
+++ b/src/any.rs
@@ -285,6 +285,7 @@ any! {
                                 Hvcc, Lhvc,
                             Mp4a,
                                 Esds,
+                            Mp4v,
                             Tx3g,
                                 Ftab,
                             Vp08, Vp09,

--- a/src/moov/trak/mdia/minf/stbl/stsd/audio.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/audio.rs
@@ -10,24 +10,42 @@ pub struct Audio {
     pub sample_rate: FixedPoint<u16>,
 }
 
-impl Encode for Audio {
-    fn encode<B: BufMut>(&self, buf: &mut B) -> Result<()> {
-        0u32.encode(buf)?; // reserved
-        0u16.encode(buf)?; // reserved
-        self.data_reference_index.encode(buf)?;
-        0u16.encode(buf)?; // version
-        0u16.encode(buf)?; // reserved
-        0u32.encode(buf)?; // reserved
-        self.channel_count.encode(buf)?;
-        self.sample_size.encode(buf)?;
-        0u32.encode(buf)?; // reserved
-        self.sample_rate.encode(buf)?;
-
-        Ok(())
-    }
+/// The QuickTime **version-2** sound sample description fields (QTFF).
+///
+/// A version-2 `AudioSampleEntry` (which `lpcm` mandates, and which carries
+/// rates/channel-counts the legacy fields cannot represent) sets the base
+/// [`Audio`] `channel_count` / `sample_size` / `sample_rate` to spec-mandated
+/// placeholders; the real values live here, alongside the CoreAudio LPCM
+/// `format_flags` that name the storage format (float vs int, endianness).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SoundV2 {
+    /// `audioSampleRate` — the real rate (the on-disk `f64` rounded to an
+    /// integer; LPCM rates are integral).
+    pub sample_rate: u32,
+    /// `numAudioChannels` — the real channel count.
+    pub channel_count: u32,
+    /// `constBitsPerChannel` — bits per sample.
+    pub bits_per_channel: u32,
+    /// `formatSpecificFlags` — CoreAudio LPCM flags (bit 0 = float, bit 1 =
+    /// big-endian, bit 2 = signed integer, …).
+    pub format_flags: u32,
 }
-impl Decode for Audio {
-    fn decode<B: Buf>(buf: &mut B) -> Result<Self> {
+
+impl Audio {
+    /// Decode the `AudioSampleEntry` base plus any QuickTime v1/v2 sound sample
+    /// description extension. The v1 extension carries no field a consumer needs
+    /// (it is skipped); the v2 extension's real rate / channels / format is
+    /// returned as [`SoundV2`]. Plain [`Decode`] discards the extension.
+    ///
+    /// Round-trip caveat: the version-2 `constBytesPerAudioPacket` and
+    /// `constLPCMFramesPerAudioPacket` fields are NOT retained — [`SoundV2`]
+    /// keeps only rate / channels / bits / flags — and [`Self::encode_with_v2`]
+    /// reconstructs them as `channels * bits/8` and `1`. A `decode`→`encode`
+    /// round-trip therefore reproduces them exactly only for uncompressed PCM
+    /// with an integer number of bytes per sample and one frame per packet
+    /// (which is what a version-2 `lpcm` entry is).
+    pub fn decode_with_v2<B: Buf>(buf: &mut B) -> Result<(Self, Option<SoundV2>)> {
         u32::decode(buf)?; // reserved
         u16::decode(buf)?; // reserved
         let data_reference_index = u16::decode(buf)?;
@@ -39,28 +57,124 @@ impl Decode for Audio {
         u32::decode(buf)?; // pre-defined, reserved
         let sample_rate = FixedPoint::decode(buf)?;
 
-        match version {
-            0 => {}
+        let v2 = match version {
+            0 => None,
             1 => {
-                // Quicktime sound sample description version 1.
+                // QuickTime sound sample description version 1.
                 u64::decode(buf)?;
                 u64::decode(buf)?;
+                None
             }
             2 => {
-                // Quicktime sound sample description version 2.
-                u32::decode(buf)?;
-                let _sample_rate = u64::decode(buf)?;
-                let _channel_count = u32::decode(buf)?;
-                <[u8; 20]>::decode(buf)?;
+                // QuickTime sound sample description version 2.
+                u32::decode(buf)?; // sizeOfStructOnly
+                let sample_rate = f64::from_bits(u64::decode(buf)?).round() as u32;
+                let channel_count = u32::decode(buf)?;
+                u32::decode(buf)?; // always7F000000
+                let bits_per_channel = u32::decode(buf)?;
+                let format_flags = u32::decode(buf)?;
+                u32::decode(buf)?; // constBytesPerAudioPacket
+                u32::decode(buf)?; // constLPCMFramesPerAudioPacket
+                Some(SoundV2 {
+                    sample_rate,
+                    channel_count,
+                    bits_per_channel,
+                    format_flags,
+                })
             }
             n => return Err(Error::UnknownQuicktimeVersion(n)),
+        };
+
+        Ok((
+            Self {
+                data_reference_index,
+                channel_count,
+                sample_size,
+                sample_rate,
+            },
+            v2,
+        ))
+    }
+
+    /// Encode the `AudioSampleEntry` base, emitting the version-2 sound sample
+    /// description extension when `v2` is `Some` (the base fields then carry the
+    /// QTFF placeholders and `version` becomes 2). `None` writes the version-0
+    /// form — the shared [`Encode`] path.
+    ///
+    /// The v2 `constBytesPerAudioPacket` / `constLPCMFramesPerAudioPacket` fields
+    /// are reconstructed as `channel_count * bits_per_channel/8` and `1` (they
+    /// are not carried on [`SoundV2`]) — exact for uncompressed one-frame-per-
+    /// packet PCM; see [`Self::decode_with_v2`].
+    pub fn encode_with_v2<B: BufMut>(&self, v2: Option<&SoundV2>, buf: &mut B) -> Result<()> {
+        0u32.encode(buf)?; // reserved
+        0u16.encode(buf)?; // reserved
+        self.data_reference_index.encode(buf)?;
+        (if v2.is_some() { 2u16 } else { 0u16 }).encode(buf)?; // version
+        0u16.encode(buf)?; // reserved
+        0u32.encode(buf)?; // reserved
+        self.channel_count.encode(buf)?;
+        self.sample_size.encode(buf)?;
+        0u32.encode(buf)?; // reserved
+        self.sample_rate.encode(buf)?;
+
+        if let Some(v2) = v2 {
+            72u32.encode(buf)?; // sizeOfStructOnly (constant)
+            (v2.sample_rate as f64).to_bits().encode(buf)?; // audioSampleRate
+            v2.channel_count.encode(buf)?;
+            0x7F00_0000u32.encode(buf)?; // always7F000000
+            v2.bits_per_channel.encode(buf)?;
+            v2.format_flags.encode(buf)?;
+            (v2.channel_count * (v2.bits_per_channel / 8)).encode(buf)?; // constBytesPerAudioPacket
+            1u32.encode(buf)?; // constLPCMFramesPerAudioPacket
         }
 
-        Ok(Self {
-            data_reference_index,
-            channel_count,
-            sample_size,
-            sample_rate,
-        })
+        Ok(())
+    }
+}
+
+impl Encode for Audio {
+    fn encode<B: BufMut>(&self, buf: &mut B) -> Result<()> {
+        self.encode_with_v2(None, buf)
+    }
+}
+impl Decode for Audio {
+    fn decode<B: Buf>(buf: &mut B) -> Result<Self> {
+        Ok(Self::decode_with_v2(buf)?.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A QuickTime **version-1** sound sample description: `decode_with_v2` must
+    // consume the 16-byte v1 extension (samples/bytes-per-packet/frame/sample)
+    // and discard it — returning the base fields with NO `SoundV2` (that is the
+    // version-2 path). Distinct from `pcm::tests::test_pcm_v1_chnl`, which
+    // exercises the PCM `pcmC`/`chnl` child boxes, not the sound-description
+    // version.
+    #[test]
+    fn test_audio_v1_extension_is_skipped() {
+        let bytes: &[u8] = &[
+            0, 0, 0, 0, // reserved
+            0, 0, // reserved
+            0, 1, // data_reference_index
+            0, 1, // version = 1
+            0, 0, // reserved
+            0, 0, 0, 0, // reserved
+            0, 2, // channel_count
+            0, 16, // sample_size
+            0, 0, 0, 0, // pre-defined + reserved
+            0xbb, 0x80, 0, 0, // sample_rate = 48000 << 16
+            // version-1 extension (16 bytes) — consumed and discarded.
+            0, 0, 4, 0, 0, 0, 0, 1, 0, 0, 0, 4, 0, 0, 0, 2,
+        ];
+
+        let (audio, v2) = Audio::decode_with_v2(&mut &bytes[..]).expect("version-1 entry decodes");
+        assert!(v2.is_none(), "a version-1 entry yields no SoundV2");
+        assert_eq!(audio.data_reference_index, 1);
+        assert_eq!(audio.channel_count, 2);
+        assert_eq!(audio.sample_size, 16);
+        assert_eq!(audio.sample_rate.integer(), 48000);
     }
 }

--- a/src/moov/trak/mdia/minf/stbl/stsd/mod.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/mod.rs
@@ -13,6 +13,7 @@ mod ftab;
 mod h264;
 mod hevc;
 mod mp4a;
+mod mp4v;
 mod opus;
 mod pasp;
 mod pcm;
@@ -39,6 +40,7 @@ pub use ftab::*;
 pub use h264::*;
 pub use hevc::*;
 pub use mp4a::*;
+pub use mp4v::*;
 pub use opus::*;
 pub use pasp::*;
 pub use pcm::*;
@@ -84,6 +86,9 @@ pub enum Codec {
 
     // AAC
     Mp4a(Mp4a),
+
+    // MPEG-4 Part 2 Visual
+    Mp4v(Mp4v),
 
     // Text
     Tx3g(Tx3g),
@@ -138,6 +143,7 @@ impl Decode for Codec {
             Any::Vp08(atom) => atom.into(),
             Any::Vp09(atom) => atom.into(),
             Any::Mp4a(atom) => atom.into(),
+            Any::Mp4v(atom) => atom.into(),
             Any::Tx3g(atom) => atom.into(),
             Any::Av01(atom) => atom.into(),
             Any::Opus(atom) => atom.into(),
@@ -175,6 +181,7 @@ impl Encode for Codec {
             Self::Vp08(atom) => atom.encode(buf),
             Self::Vp09(atom) => atom.encode(buf),
             Self::Mp4a(atom) => atom.encode(buf),
+            Self::Mp4v(atom) => atom.encode(buf),
             Self::Tx3g(atom) => atom.encode(buf),
             Self::Av01(atom) => atom.encode(buf),
             Self::Opus(atom) => atom.encode(buf),

--- a/src/moov/trak/mdia/minf/stbl/stsd/mp4a/esds.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/mp4a/esds.rs
@@ -30,8 +30,28 @@ impl AtomExt for Esds {
     }
 
     fn encode_body_ext<B: BufMut>(&self, buf: &mut B) -> Result<()> {
-        Descriptor::from(self.es_desc).encode(buf)
+        Descriptor::from(self.es_desc.clone()).encode(buf)
     }
+}
+
+/// Decode a descriptor body of `size` bytes, tolerating trailing bytes the
+/// specific descriptor doesn't consume.
+///
+/// MPEG-4 (ISO/IEC 14496-1) descriptors are length-prefixed and forward-
+/// compatible: the size field is authoritative and a parser skips to the
+/// declared end, ignoring extension fields (or writer padding) it doesn't
+/// understand. Unlike [`Decode::decode_exact`] this does not `ShortRead` on the
+/// leftover — e.g. a 2-byte `SLConfigDescriptor` (`predefined` + a trailing
+/// byte) decodes instead of failing the whole `esds`. The `size` slice still
+/// bounds the read, so a descriptor can never run past its declared length.
+fn decode_descriptor_body<T: Decode, B: Buf>(buf: &mut B, size: usize) -> Result<T> {
+    if buf.remaining() < size {
+        return Err(Error::OutOfBounds);
+    }
+    let mut inner = buf.slice(size);
+    let res = T::decode(&mut inner)?;
+    buf.advance(size);
+    Ok(res)
 }
 
 macro_rules! descriptors {
@@ -59,7 +79,7 @@ macro_rules! descriptors {
 
                 match tag {
                     $(
-                        $name::TAG => Ok($name::decode_exact(buf, size as _)?.into()),
+                        $name::TAG => Ok(decode_descriptor_body::<$name, _>(buf, size as _)?.into()),
                     )*
                     _ => Ok(Descriptor::Unknown(tag, Vec::decode_exact(buf, size as _)?)),
                 }
@@ -135,7 +155,7 @@ descriptors! {
     SLConfig,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EsDescriptor {
     pub es_id: u16,
@@ -178,14 +198,14 @@ impl Encode for EsDescriptor {
         self.es_id.encode(buf)?;
         0u8.encode(buf)?;
 
-        Descriptor::from(self.dec_config).encode(buf)?;
+        Descriptor::from(self.dec_config.clone()).encode(buf)?;
         Descriptor::from(self.sl_config).encode(buf)?;
 
         Ok(())
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DecoderConfig {
     pub object_type_indication: u8,
@@ -194,7 +214,12 @@ pub struct DecoderConfig {
     pub buffer_size_db: u24,
     pub max_bitrate: u32,
     pub avg_bitrate: u32,
-    pub dec_specific: DecoderSpecific,
+    /// The `DecoderSpecificInfo` (tag 0x05). ISO/IEC 14496-1 makes this
+    /// child optional ("if available"): a stream whose config can be derived
+    /// in-band (e.g. AAC carried with ADTS headers) legitimately omits it, so a
+    /// missing tag 5 must not fail the whole `esds`. `None` means the container
+    /// carried no out-of-band config.
+    pub dec_specific: Option<DecoderSpecific>,
 }
 
 impl DecoderConfig {
@@ -228,7 +253,7 @@ impl Decode for DecoderConfig {
             buffer_size_db,
             max_bitrate,
             avg_bitrate,
-            dec_specific: dec_specific.ok_or(Error::MissingDescriptor(DecoderSpecific::TAG))?,
+            dec_specific,
         })
     }
 }
@@ -241,70 +266,107 @@ impl Encode for DecoderConfig {
         self.max_bitrate.encode(buf)?;
         self.avg_bitrate.encode(buf)?;
 
-        Descriptor::from(self.dec_specific).encode(buf)?;
+        if let Some(dec_specific) = &self.dec_specific {
+            Descriptor::from(dec_specific.clone()).encode(buf)?;
+        }
 
         Ok(())
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DecoderSpecific {
     pub profile: u8,
     pub freq_index: u8,
     pub chan_conf: u8,
+    /// The complete `DecoderSpecificInfo` payload. For AAC this is the
+    /// AudioSpecificConfig — the `profile` / `freq_index` / `chan_conf` fields
+    /// above are a parsed view of its prefix. For a non-AAC object type (e.g.
+    /// the MPEG-4 Visual VOS/VOL config carried by an `mp4v` `esds`) the fields
+    /// are not meaningful, but the bytes are preserved verbatim so the
+    /// descriptor round-trips faithfully. Empty on a hand-constructed AAC
+    /// config, in which case [`Encode`] re-derives the 2-byte AudioSpecificConfig
+    /// from the fields.
+    pub raw: Vec<u8>,
 }
 
 impl DecoderSpecific {
     pub const TAG: u8 = 0x05;
 }
 
+/// Best-effort parse of the AAC AudioSpecificConfig prefix (`audioObjectType`,
+/// `samplingFrequencyIndex`, `channelConfiguration`) from the raw payload.
+/// Returns zeros when the payload is too short to parse (e.g. a non-AAC config);
+/// the raw bytes remain the source of truth for round-tripping.
+fn parse_audio_specific_config(raw: &[u8]) -> (u8, u8, u8) {
+    if raw.len() < 2 {
+        return (0, 0, 0);
+    }
+    let byte_a = raw[0];
+    let byte_b = raw[1];
+
+    let mut profile = byte_a >> 3;
+    if profile == 31 {
+        profile = 32 + ((byte_a & 7) | (byte_b >> 5));
+    }
+
+    let freq_index = if profile > 31 {
+        (byte_b >> 1) & 0x0F
+    } else {
+        ((byte_a & 0x07) << 1) + (byte_b >> 7)
+    };
+
+    let chan_conf = if freq_index == 15 {
+        // The 24-bit explicit sample rate precedes the channel config.
+        if raw.len() >= 5 {
+            let sample_rate =
+                (u32::from(raw[2]) << 16) | (u32::from(raw[3]) << 8) | u32::from(raw[4]);
+            ((sample_rate >> 4) & 0x0F) as u8
+        } else {
+            0
+        }
+    } else if profile > 31 {
+        if raw.len() >= 3 {
+            (byte_b & 1) | (raw[2] & 0xE0)
+        } else {
+            0
+        }
+    } else {
+        (byte_b >> 3) & 0x0F
+    };
+
+    (profile, freq_index, chan_conf)
+}
+
 impl Decode for DecoderSpecific {
     fn decode<B: Buf>(buf: &mut B) -> Result<Self> {
-        let byte_a = u8::decode(buf)?;
-        let byte_b = u8::decode(buf)?;
-
-        let mut profile = byte_a >> 3;
-        if profile == 31 {
-            profile = 32 + ((byte_a & 7) | (byte_b >> 5));
-        }
-
-        let freq_index = if profile > 31 {
-            (byte_b >> 1) & 0x0F
-        } else {
-            ((byte_a & 0x07) << 1) + (byte_b >> 7)
-        };
-
-        let chan_conf;
-        if freq_index == 15 {
-            // Skip the 24 bit sample rate
-            // TODO this needs to be implemented in encode
-            let sample_rate = u24::decode(buf)?;
-            chan_conf = ((u32::from(sample_rate) >> 4) & 0x0F) as u8;
-        } else if profile > 31 {
-            let byte_c = u8::decode(buf)?;
-            chan_conf = (byte_b & 1) | (byte_c & 0xE0);
-        } else {
-            chan_conf = (byte_b >> 3) & 0x0F;
-        }
-
-        if buf.has_remaining() {
-            tracing::warn!("PLEASE FIX: failed to consume all bytes in DecoderSpecificDescriptor");
-            buf.advance(buf.remaining());
-        }
+        // Capture the complete payload (the descriptor body is already
+        // size-bounded by `decode_descriptor_body`) so any object type
+        // round-trips; the AAC fields are a best-effort parse of its prefix.
+        let raw = Vec::decode(buf)?;
+        let (profile, freq_index, chan_conf) = parse_audio_specific_config(&raw);
 
         Ok(DecoderSpecific {
             profile,
             freq_index,
             chan_conf,
+            raw,
         })
     }
 }
 
 impl Encode for DecoderSpecific {
     fn encode<B: BufMut>(&self, buf: &mut B) -> Result<()> {
-        ((self.profile << 3) + (self.freq_index >> 1)).encode(buf)?;
-        ((self.freq_index << 7) + (self.chan_conf << 3)).encode(buf)?;
+        if self.raw.is_empty() {
+            // Hand-constructed AAC config with no preserved bytes: re-derive the
+            // 2-byte AudioSpecificConfig from the fields.
+            ((self.profile << 3) + (self.freq_index >> 1)).encode(buf)?;
+            ((self.freq_index << 7) + (self.chan_conf << 3)).encode(buf)?;
+        } else {
+            // Emit the preserved payload verbatim (faithful for any object type).
+            self.raw.encode(buf)?;
+        }
 
         Ok(())
     }
@@ -329,5 +391,76 @@ impl Encode for SLConfig {
     fn encode<B: BufMut>(&self, buf: &mut B) -> Result<()> {
         2u8.encode(buf)?; // pre-defined
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // An `esds` whose `SLConfigDescriptor` (tag 0x06) declares 2 bytes — a
+    // `predefined` value plus a trailing byte — instead of the usual 1.
+    // `SLConfig::decode` reads only `predefined`, so the strict `decode_exact`
+    // used to `ShortRead` and fail the whole `esds` with `UnderDecode(esds)`.
+    // ISO 14496-1 makes the descriptor length authoritative, so the trailing
+    // byte must be skipped. Descriptor tree: EsDescriptor(0x03) → DecoderConfig
+    // (0x04) → DecoderSpecific(0x05, AAC-LC 48 kHz) + SLConfig(0x06, 2 bytes).
+    const ESDS_2BYTE_SLCONFIG: &[u8] = &[
+        0x00, 0x00, 0x00, 0x28, b'e', b's', b'd', b's', // esds box, size 40
+        0x00, 0x00, 0x00, 0x00, // version + flags
+        0x03, 0x1a, 0x00, 0x01, 0x00, // EsDescriptor: size 26, es_id 1, flags 0
+        0x04, 0x11, 0x40, 0x15, // DecoderConfig: size 17, oti 0x40, stream/up 0x15
+        0x00, 0x00, 0x00, // buffer_size_db
+        0x00, 0x00, 0x00, 0x00, // max_bitrate
+        0x00, 0x00, 0x00, 0x00, // avg_bitrate
+        0x05, 0x02, 0x11, 0x90, // DecoderSpecific: size 2 (profile 2, freq 3, chan 2)
+        0x06, 0x02, 0x02, 0x15, // SLConfig: size 2 = predefined 0x02 + a trailing byte
+    ];
+
+    #[test]
+    fn test_esds_two_byte_slconfig() {
+        let esds =
+            Esds::decode(&mut &ESDS_2BYTE_SLCONFIG[..]).expect("2-byte SLConfig must be tolerated");
+        let dec = esds
+            .es_desc
+            .dec_config
+            .dec_specific
+            .expect("DecoderSpecificInfo present");
+        assert_eq!(dec.profile, 2, "AAC-LC");
+        assert_eq!(dec.freq_index, 3, "48 kHz");
+    }
+
+    // A `DecoderConfigDescriptor` (tag 0x04) with NO `DecoderSpecificInfo`
+    // (tag 0x05) child — valid per ISO/IEC 14496-1, where the DecSpecificInfo
+    // is optional (e.g. AAC whose config is carried in-band via ADTS headers).
+    // Before the fix the mandatory `MissingDescriptor(0x05)` rejected the whole
+    // `esds`; now the field decodes to `None`. Descriptor tree: EsDescriptor
+    // (0x03) → DecoderConfig(0x04, no tag-5 child) + SLConfig(0x06).
+    const ESDS_NO_DEC_SPECIFIC: &[u8] = &[
+        0x00, 0x00, 0x00, 0x23, b'e', b's', b'd', b's', // esds box, size 35
+        0x00, 0x00, 0x00, 0x00, // version + flags
+        0x03, 0x15, 0x00, 0x01, 0x00, // EsDescriptor: size 21, es_id 1, flags 0
+        0x04, 0x0d, 0x40, 0x15, // DecoderConfig: size 13, oti 0x40 (AAC), stream/up 0x15
+        0x00, 0x00, 0x00, // buffer_size_db
+        0x00, 0x00, 0x00, 0x00, // max_bitrate
+        0x00, 0x00, 0x00, 0x00, // avg_bitrate
+        0x06, 0x01, 0x02, // SLConfig: size 1, predefined 0x02
+    ];
+
+    #[test]
+    fn test_esds_missing_dec_specific() {
+        let esds = Esds::decode(&mut &ESDS_NO_DEC_SPECIFIC[..])
+            .expect("a DecoderConfig without a DecoderSpecificInfo must be tolerated");
+        assert_eq!(esds.es_desc.dec_config.object_type_indication, 0x40);
+        assert!(
+            esds.es_desc.dec_config.dec_specific.is_none(),
+            "no tag-5 child decodes to None, not an error"
+        );
+
+        // And it round-trips: a `None` dec_specific emits no tag-5 descriptor.
+        let mut buf = Vec::new();
+        esds.encode(&mut buf).unwrap();
+        let again = Esds::decode(&mut buf.as_slice()).unwrap();
+        assert_eq!(again, esds);
     }
 }

--- a/src/moov/trak/mdia/minf/stbl/stsd/mp4a/mod.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/mp4a/mod.rs
@@ -107,11 +107,12 @@ mod tests {
                         buffer_size_db: Default::default(),
                         max_bitrate: 67695,
                         avg_bitrate: 67695,
-                        dec_specific: esds::DecoderSpecific {
+                        dec_specific: Some(esds::DecoderSpecific {
                             profile: 2,
                             freq_index: 4,
                             chan_conf: 2,
-                        },
+                            raw: vec![0x12, 0x10],
+                        }),
                     },
                     sl_config: esds::SLConfig::default(),
                 },
@@ -161,11 +162,12 @@ mod tests {
                     buffer_size_db: Default::default(),
                     max_bitrate: 67695,
                     avg_bitrate: 67695,
-                    dec_specific: esds::DecoderSpecific {
+                    dec_specific: Some(esds::DecoderSpecific {
                         profile: 2,
                         freq_index: 4,
                         chan_conf: 2,
-                    },
+                        raw: vec![0x12, 0x10],
+                    }),
                 },
                 sl_config: esds::SLConfig::default(),
             },
@@ -226,11 +228,12 @@ mod tests {
                         buffer_size_db: Default::default(),
                         max_bitrate: 67695,
                         avg_bitrate: 67695,
-                        dec_specific: esds::DecoderSpecific {
+                        dec_specific: Some(esds::DecoderSpecific {
                             profile: 2,
                             freq_index: 4,
                             chan_conf: 2,
-                        },
+                            raw: vec![0x12, 0x10],
+                        }),
                     },
                     sl_config: esds::SLConfig::default(),
                 },

--- a/src/moov/trak/mdia/minf/stbl/stsd/mp4v.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/mp4v.rs
@@ -1,0 +1,127 @@
+use crate::*;
+
+/// MPEG-4 Part 2 Visual (ISO/IEC 14496-2) — the `mp4v` sample entry.
+///
+/// A `VisualSampleEntry` whose codec configuration rides in an MPEG-4 `esds`
+/// (the same elementary-stream descriptor container as `mp4a`, here with a
+/// visual object-type indication such as `0x20`). Common in older MP4/3GP files
+/// (DivX/Xvid, MPEG-4 SP/ASP). Optional `pasp`/`colr`/`btrt`/`fiel` children are
+/// carried like the other visual entries.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Mp4v {
+    pub visual: Visual,
+    pub esds: Esds,
+    pub btrt: Option<Btrt>,
+    pub colr: Option<Colr>,
+    pub pasp: Option<Pasp>,
+    pub fiel: Option<Fiel>,
+}
+
+impl Atom for Mp4v {
+    const KIND: FourCC = FourCC::new(b"mp4v");
+
+    fn decode_body<B: Buf>(buf: &mut B) -> Result<Self> {
+        let visual = Visual::decode(buf)?;
+
+        let mut esds = None;
+        let mut btrt = None;
+        let mut colr = None;
+        let mut pasp = None;
+        let mut fiel = None;
+        while let Some(atom) = Any::decode_maybe(buf)? {
+            match atom {
+                Any::Esds(atom) => esds = Some(atom),
+                Any::Btrt(atom) => btrt = Some(atom),
+                Any::Colr(atom) => colr = Some(atom),
+                Any::Pasp(atom) => pasp = Some(atom),
+                Any::Fiel(atom) => fiel = Some(atom),
+                unknown => Self::decode_unknown(&unknown)?,
+            }
+        }
+        Ok(Mp4v {
+            visual,
+            esds: esds.ok_or(Error::MissingBox(Esds::KIND))?,
+            btrt,
+            colr,
+            pasp,
+            fiel,
+        })
+    }
+
+    fn encode_body<B: BufMut>(&self, buf: &mut B) -> Result<()> {
+        self.visual.encode(buf)?;
+        self.esds.encode(buf)?;
+        self.btrt.encode(buf)?;
+        self.colr.encode(buf)?;
+        self.pasp.encode(buf)?;
+        self.fiel.encode(buf)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_esds() -> Esds {
+        Esds {
+            es_desc: esds::EsDescriptor {
+                es_id: 1,
+                // object_type_indication 0x20 = MPEG-4 Visual; stream_type 0x04
+                // = VisualStream.
+                dec_config: esds::DecoderConfig {
+                    object_type_indication: 0x20,
+                    stream_type: 0x04,
+                    up_stream: 0,
+                    buffer_size_db: Default::default(),
+                    max_bitrate: 0,
+                    avg_bitrate: 0,
+                    // A representative MPEG-4 Visual DecoderSpecificInfo — the
+                    // VisualObjectSequence / VideoObject start codes and VOL
+                    // header. These bytes are opaque to the AAC field parse
+                    // (`profile`/`freq_index`/`chan_conf` resolve to 0), but are
+                    // preserved verbatim in `raw` so the config round-trips.
+                    dec_specific: Some(esds::DecoderSpecific {
+                        profile: 0,
+                        freq_index: 0,
+                        chan_conf: 0,
+                        raw: vec![0x00, 0x00, 0x01, 0xb0, 0x01, 0x00, 0x00, 0x01, 0xb5],
+                    }),
+                },
+                sl_config: esds::SLConfig::default(),
+            },
+        }
+    }
+
+    #[test]
+    fn test_mp4v_roundtrip() {
+        let expected = Mp4v {
+            visual: Visual {
+                data_reference_index: 1,
+                width: 640,
+                height: 480,
+                horizresolution: 0x48.into(),
+                vertresolution: 0x48.into(),
+                frame_count: 1,
+                compressor: "".into(),
+                depth: 24,
+            },
+            esds: sample_esds(),
+            btrt: None,
+            colr: None,
+            pasp: None,
+            fiel: None,
+        };
+
+        let mut buf = Vec::new();
+        expected.encode(&mut buf).unwrap();
+
+        let mut buf = buf.as_ref();
+        let decoded = Mp4v::decode(&mut buf).unwrap();
+        assert_eq!(decoded, expected);
+        assert_eq!(decoded.visual.width, 640);
+        assert_eq!(decoded.visual.height, 480);
+        assert_eq!(decoded.esds.es_desc.dec_config.object_type_indication, 0x20);
+    }
+}

--- a/src/moov/trak/mdia/minf/stbl/stsd/pcm.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/pcm.rs
@@ -65,15 +65,20 @@ pub struct Pcm {
     pub pcmc: Option<PcmC>,
     pub chnl: Option<Chnl>,
     pub btrt: Option<Btrt>,
+    /// QuickTime version-2 sound sample description fields, when the entry was
+    /// written as a v2 `AudioSampleEntry` (the `lpcm` case — see [`SoundV2`]).
+    pub sound_v2: Option<SoundV2>,
 }
 
 impl Pcm {
+    #[allow(clippy::too_many_arguments)]
     fn encode_fields<B: BufMut>(
         fourcc: FourCC,
         audio: &Audio,
         pcmc: Option<&PcmC>,
         chnl: Option<&Chnl>,
         btrt: Option<&Btrt>,
+        sound_v2: Option<&SoundV2>,
         buf: &mut B,
     ) -> Result<()> {
         // An ipcm/fpcm entry without its mandatory pcmC box is invalid (ISO/IEC 23003-5).
@@ -81,7 +86,7 @@ impl Pcm {
             return Err(Error::MissingBox(PcmC::KIND));
         }
 
-        audio.encode(buf)?;
+        audio.encode_with_v2(sound_v2, buf)?;
 
         if let Some(pcmc) = pcmc {
             pcmc.encode(buf)?;
@@ -99,7 +104,7 @@ impl Pcm {
     }
 
     pub fn decode_with_fourcc<B: Buf>(fourcc: FourCC, buf: &mut B) -> Result<Self> {
-        let audio = Audio::decode(buf)?;
+        let (audio, sound_v2) = Audio::decode_with_v2(buf)?;
 
         let mut chnl = None;
         let mut pcmc = None;
@@ -148,6 +153,7 @@ impl Pcm {
             pcmc,
             chnl,
             btrt,
+            sound_v2,
         })
     }
 
@@ -158,6 +164,7 @@ impl Pcm {
             self.pcmc.as_ref(),
             self.chnl.as_ref(),
             self.btrt.as_ref(),
+            self.sound_v2.as_ref(),
             buf,
         )
     }
@@ -171,15 +178,22 @@ impl Pcm {
     /// - `in24` / `in32`: big-endian integer, 24 / 32 bits
     /// - `fl32` / `fl64`: big-endian float, 32 / 64 bits
     /// - `s16l`: little-endian integer, 16 bits
-    /// - `lpcm`: QTFF format flags are only defined for version 2 sound sample
-    ///   descriptions, which are not decoded here; defaults to big-endian
-    ///   integer, `sample_size` bits
+    /// - `lpcm`: resolved from the version-2 sound sample description when
+    ///   present — [`SoundV2::format_flags`] (bit 0 = float, bit 1 = big-endian)
+    ///   and [`SoundV2::bits_per_channel`]. A version-0/1 `lpcm` (no `SoundV2`)
+    ///   has no format flags to consult, so it falls back to big-endian integer,
+    ///   `sample_size` bits.
     ///
     /// Returns `None` for an unknown fourcc, or for an `ipcm`/`fpcm` entry
     /// missing its mandatory `pcmC` box (which
     /// [`decode_with_fourcc`](Self::decode_with_fourcc) never produces).
     pub fn format(&self) -> Option<PcmFormat> {
-        Self::resolve_format(self.fourcc, &self.audio, self.pcmc.as_ref())
+        Self::resolve_format(
+            self.fourcc,
+            &self.audio,
+            self.pcmc.as_ref(),
+            self.sound_v2.as_ref(),
+        )
     }
 
     /// Whether a PCM sample entry with this fourcc must carry a `pcmC` box.
@@ -190,9 +204,28 @@ impl Pcm {
         matches!(fourcc, Ipcm::KIND | Fpcm::KIND)
     }
 
-    fn resolve_format(fourcc: FourCC, audio: &Audio, pcmc: Option<&PcmC>) -> Option<PcmFormat> {
+    fn resolve_format(
+        fourcc: FourCC,
+        audio: &Audio,
+        pcmc: Option<&PcmC>,
+        sound_v2: Option<&SoundV2>,
+    ) -> Option<PcmFormat> {
         // fl32/fl64 samples are float, as are fpcm samples (ISO/IEC 23003-5).
         let float = matches!(fourcc, Fl32::KIND | Fl64::KIND | Fpcm::KIND);
+
+        // A version-2 `lpcm` entry names its real storage format in the
+        // CoreAudio `formatSpecificFlags` (QTFF): bit 0 = float, bit 1 =
+        // big-endian. This is the only faithful source for `lpcm` — the
+        // fourcc-implied default below is a guess.
+        if fourcc == Lpcm::KIND {
+            if let Some(v2) = sound_v2 {
+                return Some(PcmFormat {
+                    big_endian: v2.format_flags & 0x2 != 0,
+                    sample_size: v2.bits_per_channel as u16,
+                    float: v2.format_flags & 0x1 != 0,
+                });
+            }
+        }
 
         if let Some(pcmc) = pcmc {
             return Some(PcmFormat {
@@ -244,7 +277,9 @@ macro_rules! define_pcm_sample_entry {
             ///
             /// See [`Pcm::format`] for the resolution rules.
             pub fn format(&self) -> Option<PcmFormat> {
-                Pcm::resolve_format(Self::KIND, &self.audio, self.pcmc.as_ref())
+                // These fourccs are only ever written as version-0 sample
+                // entries, so there is no `SoundV2` to consult (see `Lpcm`).
+                Pcm::resolve_format(Self::KIND, &self.audio, self.pcmc.as_ref(), None)
             }
         }
 
@@ -268,6 +303,7 @@ macro_rules! define_pcm_sample_entry {
                     self.pcmc.as_ref(),
                     self.chnl.as_ref(),
                     self.btrt.as_ref(),
+                    None,
                     buf,
                 )
             }
@@ -277,7 +313,6 @@ macro_rules! define_pcm_sample_entry {
 
 define_pcm_sample_entry!(Sowt, b"sowt");
 define_pcm_sample_entry!(Twos, b"twos");
-define_pcm_sample_entry!(Lpcm, b"lpcm");
 define_pcm_sample_entry!(Ipcm, b"ipcm");
 define_pcm_sample_entry!(Fpcm, b"fpcm");
 define_pcm_sample_entry!(In24, b"in24");
@@ -285,6 +320,62 @@ define_pcm_sample_entry!(In32, b"in32");
 define_pcm_sample_entry!(Fl32, b"fl32");
 define_pcm_sample_entry!(Fl64, b"fl64");
 define_pcm_sample_entry!(S16l, b"s16l");
+
+/// QuickTime Linear PCM (`lpcm`). QTFF defines this fourcc ONLY inside a
+/// **version-2** sound sample description, so — unlike the other QTFF PCM
+/// entries — it carries the real rate / channel count / storage format in its
+/// [`SoundV2`] extension (`sound_v2`) rather than in the legacy base fields
+/// (which the spec fixes to placeholders). A rare version-0/1 `lpcm` leaves
+/// `sound_v2` `None`, and [`Self::format`] falls back to the fourcc guess.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Lpcm {
+    pub audio: Audio,
+    pub pcmc: Option<PcmC>,
+    pub chnl: Option<Chnl>,
+    pub btrt: Option<Btrt>,
+    pub sound_v2: Option<SoundV2>,
+}
+
+impl Lpcm {
+    /// The resolved sample format — from the version-2 `formatSpecificFlags`
+    /// when present (see [`Pcm::format`]).
+    pub fn format(&self) -> Option<PcmFormat> {
+        Pcm::resolve_format(
+            Self::KIND,
+            &self.audio,
+            self.pcmc.as_ref(),
+            self.sound_v2.as_ref(),
+        )
+    }
+}
+
+impl Atom for Lpcm {
+    const KIND: FourCC = FourCC::new(b"lpcm");
+
+    fn decode_body<B: Buf>(buf: &mut B) -> Result<Self> {
+        let entry = Pcm::decode_with_fourcc(Self::KIND, buf)?;
+        Ok(Self {
+            audio: entry.audio,
+            pcmc: entry.pcmc,
+            chnl: entry.chnl,
+            btrt: entry.btrt,
+            sound_v2: entry.sound_v2,
+        })
+    }
+
+    fn encode_body<B: BufMut>(&self, buf: &mut B) -> Result<()> {
+        Pcm::encode_fields(
+            Self::KIND,
+            &self.audio,
+            self.pcmc.as_ref(),
+            self.chnl.as_ref(),
+            self.btrt.as_ref(),
+            self.sound_v2.as_ref(),
+            buf,
+        )
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -331,6 +422,7 @@ mod tests {
             pcmc: Some(pcmc),
             chnl: Some(chnl),
             btrt: None,
+            sound_v2: None,
         };
 
         let mut buf = Vec::new();
@@ -367,6 +459,7 @@ mod tests {
             pcmc: Some(pcmc),
             chnl: Some(chnl),
             btrt: None,
+            sound_v2: None,
         };
 
         let mut buf = Vec::new();
@@ -408,6 +501,7 @@ mod tests {
                 max_bitrate: 2_304_096,
                 avg_bitrate: 2_304_000,
             }),
+            sound_v2: None,
         };
 
         let mut buf = Vec::new();
@@ -445,6 +539,7 @@ mod tests {
             pcmc: Some(pcmc),
             chnl: Some(chnl),
             btrt: None,
+            sound_v2: None,
         };
 
         let mut buf = Vec::new();
@@ -485,6 +580,7 @@ mod tests {
             pcmc: Some(pcmc),
             chnl: Some(chnl),
             btrt: None,
+            sound_v2: None,
         };
 
         let mut buf = Vec::new();
@@ -521,6 +617,7 @@ mod tests {
             pcmc: Some(pcmc),
             chnl: Some(chnl),
             btrt: None,
+            sound_v2: None,
         };
 
         let mut buf = Vec::new();
@@ -528,6 +625,50 @@ mod tests {
 
         let decoded = Lpcm::decode(&mut &buf[..]).unwrap();
         assert_eq!(pcm, decoded);
+    }
+
+    #[test]
+    fn test_lpcm_v2_sound_description() {
+        // A version-2 `lpcm` entry: the real 48000 Hz / 2ch / 24-bit signed
+        // little-endian format lives in the `SoundV2` extension; the base fields
+        // are the QTFF placeholders. formatSpecificFlags 0x4 = signed integer,
+        // little-endian (bit 1 clear), not float (bit 0 clear) → S24LE.
+        let lpcm = Lpcm {
+            audio: Audio {
+                data_reference_index: 1,
+                channel_count: 2,
+                sample_size: 16,
+                sample_rate: FixedPoint::new(1, 0),
+            },
+            pcmc: None,
+            chnl: None,
+            btrt: None,
+            sound_v2: Some(SoundV2 {
+                sample_rate: 48000,
+                channel_count: 2,
+                bits_per_channel: 24,
+                format_flags: 0x4,
+            }),
+        };
+
+        // Round-trips through the version-2 encoding.
+        let mut buf = Vec::new();
+        lpcm.encode(&mut buf).unwrap();
+        let decoded = Lpcm::decode(&mut &buf[..]).unwrap();
+        assert_eq!(decoded, lpcm);
+
+        // The storage format is resolved from the v2 flags, not the fourcc guess.
+        assert_eq!(
+            decoded.format(),
+            Some(PcmFormat {
+                big_endian: false,
+                sample_size: 24,
+                float: false,
+            })
+        );
+        let v2 = decoded.sound_v2.expect("v2 sound description present");
+        assert_eq!(v2.sample_rate, 48000);
+        assert_eq!(v2.channel_count, 2);
     }
 
     const ENCODED_IPCM: &[u8] = &[

--- a/src/test/bbb.rs
+++ b/src/test/bbb.rs
@@ -172,11 +172,12 @@ fn bbb() {
                                                 stream_type: 5,
                                                 max_bitrate: 125587,
                                                 avg_bitrate: 125587,
-                                                dec_specific: esds::DecoderSpecific {
+                                                dec_specific: Some(esds::DecoderSpecific {
                                                     profile: 2,
                                                     freq_index: 4,
                                                     chan_conf: 2,
-                                                },
+                                                    raw: vec![0x12, 0x10],
+                                                }),
                                                 ..Default::default()
                                             },
                                             sl_config: esds::SLConfig{},

--- a/src/test/esds.rs
+++ b/src/test/esds.rs
@@ -172,11 +172,12 @@ fn esds() {
                                                 stream_type: 5,
                                                 max_bitrate: 128000,
                                                 avg_bitrate: 128000,
-                                                dec_specific: esds::DecoderSpecific {
+                                                dec_specific: Some(esds::DecoderSpecific {
                                                     profile: 2,
                                                     freq_index: 4,
                                                     chan_conf: 2,
-                                                },
+                                                    raw: vec![0x12, 0x10, 0x56, 0xe5, 0x00],
+                                                }),
                                                 ..Default::default()
                                             },
                                             sl_config: esds::SLConfig{},

--- a/src/test/h264.rs
+++ b/src/test/h264.rs
@@ -246,11 +246,12 @@ fn avcc_ext() {
                                                 buffer_size_db: u24::default(),
                                                 max_bitrate: 160000,
                                                 avg_bitrate: 160000,
-                                                dec_specific: esds::DecoderSpecific {
+                                                dec_specific: Some(esds::DecoderSpecific {
                                                     profile: 2,
                                                     freq_index: 3,
                                                     chan_conf: 2,
-                                                },
+                                                    raw: vec![0x11, 0x90],
+                                                }),
                                             },
                                             sl_config: esds::SLConfig::default(),
                                         },


### PR DESCRIPTION
> **Depends on #174** (the `esds` DecoderSpecificInfo payload-preservation change). This branch is stacked on it, so the diff currently includes #174's commit — it will drop out automatically once #174 merges.

Two additions that broaden real-world sample-entry coverage.

### 1. `mp4v` — MPEG-4 Part 2 Visual (ISO/IEC 14496-2)

A new `VisualSampleEntry` whose codec configuration rides in an MPEG-4 `esds` (the same descriptor container as `mp4a`, here with a visual object-type indication). Common in older MP4/3GP files (DivX/Xvid, MPEG-4 SP/ASP), where it previously decoded as `Codec::Unknown`.

Registered in the `Any` table and the `Codec` enum; optional `pasp`/`colr`/`btrt`/`fiel` children are carried like the other visual entries. The MPEG-4 Visual VOS/VOL config in the `esds` is preserved verbatim through `DecoderSpecific::raw` (from #174), so the entry round-trips faithfully.

### 2. Decode QuickTime version-2 sound sample descriptions

`Audio::decode` read the version-1/2 sound-description extensions past the base fields but **discarded** them. QTFF defines the `lpcm` fourcc *only* inside a version-2 description, so an `lpcm` entry lost its real sample rate, channel count, and `formatSpecificFlags` (and `Lpcm::format()` could only return a fourcc-implied guess).

`Audio` now surfaces the version-2 fields as a `SoundV2` (real rate / channels / bits-per-channel / format flags), exposed on the `Pcm` helper and a hand-written `Lpcm` entry, so `Lpcm::format()` resolves the true storage format — float vs integer, endianness — from the flags. A version-2 entry round-trips through encode.

Both additions include tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
