### PR TITLE
Validate vpcC chroma subsampling during encoding

### DIFF
--- a/src/moov/trak/mdia/minf/stbl/stsd/vp9/vpcc.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/vp9/vpcc.rs
@@ -52,8 +52,8 @@ impl AtomExt for VpcC {
     }
 
     fn encode_body_ext<B: BufMut>(&self, buf: &mut B) -> Result<VpccExt> {
-        if self.chroma_subsampling > 0x07 {
-            return Err(Error::InvalidSize);
+        if self.chroma_subsampling > 3 {
+            return Err(Error::Reserved);
         }
 
         self.profile.encode(buf)?;
@@ -99,9 +99,9 @@ mod tests {
 
     #[test]
     fn test_vpcc_chroma_subsampling() {
-        for chroma_subsampling in 0..=7 {
+        for chroma_subsampling in 0..=3 {
             let expected = VpcC {
-                profile: 1,
+                profile: if chroma_subsampling < 2 { 0 } else { 1 },
                 level: 0x1F,
                 bit_depth: 8,
                 chroma_subsampling,
@@ -121,15 +121,14 @@ mod tests {
     }
 
     #[test]
-    fn test_vpcc_rejects_chroma_subsampling_that_exceeds_field() {
-        let vpcc = VpcC {
-            chroma_subsampling: 8,
-            ..Default::default()
-        };
+    fn test_vpcc_rejects_reserved_chroma_subsampling() {
+        for chroma_subsampling in 4..=u8::MAX {
+            let vpcc = VpcC {
+                chroma_subsampling,
+                ..Default::default()
+            };
 
-        assert!(matches!(
-            vpcc.encode(&mut Vec::new()),
-            Err(Error::InvalidSize)
-        ));
+            assert!(matches!(vpcc.encode(&mut Vec::new()), Err(Error::Reserved)));
+        }
     }
 }

--- a/src/moov/trak/mdia/minf/stbl/stsd/vp9/vpcc.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/vp9/vpcc.rs
@@ -52,6 +52,10 @@ impl AtomExt for VpcC {
     }
 
     fn encode_body_ext<B: BufMut>(&self, buf: &mut B) -> Result<VpccExt> {
+        if self.chroma_subsampling > 0x07 {
+            return Err(Error::InvalidSize);
+        }
+
         self.profile.encode(buf)?;
         self.level.encode(buf)?;
         ((self.bit_depth << 4)
@@ -95,8 +99,7 @@ mod tests {
 
     #[test]
     fn test_vpcc_chroma_subsampling() {
-        // chroma_subsampling is a 3-bit field: 0/1 = 4:2:0, 2 = 4:2:2, 3 = 4:4:4
-        for chroma_subsampling in [2, 3] {
+        for chroma_subsampling in 0..=7 {
             let expected = VpcC {
                 profile: 1,
                 level: 0x1F,
@@ -115,5 +118,18 @@ mod tests {
             let decoded = VpcC::decode(&mut buf).unwrap();
             assert_eq!(decoded, expected);
         }
+    }
+
+    #[test]
+    fn test_vpcc_rejects_chroma_subsampling_that_exceeds_field() {
+        let vpcc = VpcC {
+            chroma_subsampling: 8,
+            ..Default::default()
+        };
+
+        assert!(matches!(
+            vpcc.encode(&mut Vec::new()),
+            Err(Error::InvalidSize)
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- reject `chroma_subsampling` values outside the defined `0..=3` range with `Error::Reserved`
- exercise round trips for all four defined values using compatible VP9 profiles
- add regression coverage for every reserved or out-of-range `u8` value

## Why

The `vpcC` field is three bits wide, but only values 0 through 3 are defined; values 4 through 7 are reserved. Encoding previously accepted any `u8`, so reserved values could produce invalid codec configuration records and values above 7 could bleed into the `bit_depth` nibble.

Encoding now rejects every undefined chroma subsampling value.

## Validation

- `just check`
- `just test` — 237 tests passed

Closes #193
