### PR TITLE
Return errors for malformed metadata atoms

### DIFF
--- a/src/meta/iinf.rs
+++ b/src/meta/iinf.rs
@@ -66,12 +66,11 @@ impl AtomExt for ItemInfoEntry {
             (self.item_id as u16).encode(buf)?;
             self.item_protection_index.encode(buf)?;
             self.item_name.as_str().encode(buf)?;
-            self.content_type.clone().unwrap().as_str().encode(buf)?;
-            self.content_encoding
-                .clone()
-                .unwrap_or("".to_string())
-                .as_str()
-                .encode(buf)?;
+            let content_type = self.content_type.as_deref().ok_or(Error::MissingContent(
+                "content_type required for infe version 0",
+            ))?;
+            content_type.encode(buf)?;
+            self.content_encoding.as_deref().unwrap_or("").encode(buf)?;
             if version == ItemInfoEntryVersion::V1 {
                 return Err(Error::Unsupported("infe version 1 extensions"));
             }
@@ -85,12 +84,11 @@ impl AtomExt for ItemInfoEntry {
             Some(self.item_type).encode(buf)?;
             self.item_name.as_str().encode(buf)?;
             if self.item_type == Some(FourCC::new(b"mime")) {
-                self.content_type.clone().unwrap().as_str().encode(buf)?;
-                self.content_encoding
-                    .clone()
-                    .unwrap_or("".to_string())
-                    .as_str()
-                    .encode(buf)?;
+                let content_type = self.content_type.as_deref().ok_or(Error::MissingContent(
+                    "content_type required with 'mime' item_type",
+                ))?;
+                content_type.encode(buf)?;
+                self.content_encoding.as_deref().unwrap_or("").encode(buf)?;
             } else if self.item_type == Some(FourCC::new(b"uri ")) {
                 let item_uri_type = self.item_uri_type.as_ref().ok_or(Error::MissingContent(
                     "item_uri_type required with 'uri ' item_type",
@@ -315,6 +313,52 @@ mod tests {
             }],
         };
         let mut buf = Vec::new();
+        assert!(matches!(
+            iinf.encode(&mut buf),
+            Err(Error::MissingContent(_))
+        ));
+    }
+
+    /// Rejects a version 0 item info entry when its required content type is missing.
+    #[test]
+    fn test_iinf_encode_v0_without_content_type_returns_error() {
+        let iinf = Iinf {
+            item_infos: vec![ItemInfoEntry {
+                item_id: 1,
+                item_protection_index: 0,
+                item_type: None,
+                item_name: "Item".to_string(),
+                content_type: None,
+                content_encoding: None,
+                item_uri_type: None,
+                item_not_in_presentation: false,
+            }],
+        };
+        let mut buf = Vec::new();
+
+        assert!(matches!(
+            iinf.encode(&mut buf),
+            Err(Error::MissingContent(_))
+        ));
+    }
+
+    /// Rejects a `mime` item info entry when its required content type is missing.
+    #[test]
+    fn test_iinf_encode_mime_without_content_type_returns_error() {
+        let iinf = Iinf {
+            item_infos: vec![ItemInfoEntry {
+                item_id: 1,
+                item_protection_index: 0,
+                item_type: Some(FourCC::new(b"mime")),
+                item_name: "Item".to_string(),
+                content_type: None,
+                content_encoding: None,
+                item_uri_type: None,
+                item_not_in_presentation: false,
+            }],
+        };
+        let mut buf = Vec::new();
+
         assert!(matches!(
             iinf.encode(&mut buf),
             Err(Error::MissingContent(_))

--- a/src/meta/iref.rs
+++ b/src/meta/iref.rs
@@ -29,18 +29,22 @@ impl AtomExt for Iref {
     const KIND_EXT: FourCC = FourCC::new(b"iref");
 
     fn decode_body_ext<B: Buf>(buf: &mut B, ext: IrefExt) -> Result<Self> {
-        let mut bytes_remaining = buf.remaining();
         let mut references = vec![];
-        while bytes_remaining > 0 {
+        while buf.has_remaining() {
+            let box_len = u32::decode(buf)? as usize;
+            let body_len = box_len.checked_sub(4).ok_or(Error::InvalidSize)?;
+            if body_len > buf.remaining() {
+                return Err(Error::InvalidSize);
+            }
+
+            let mut body = buf.slice(body_len);
             if ext.version == IrefVersion::V0 {
-                let box_len = u32::decode(buf)?;
-                bytes_remaining -= box_len as usize;
-                let reference_type = FourCC::decode(buf)?;
-                let from_item_id: u32 = u16::decode(buf)?.into();
-                let reference_count: u16 = u16::decode(buf)?;
+                let reference_type = FourCC::decode(&mut body)?;
+                let from_item_id: u32 = u16::decode(&mut body)?.into();
+                let reference_count: u16 = u16::decode(&mut body)?;
                 let mut to_item_ids: Vec<u32> = vec![];
                 for _ in 0..reference_count {
-                    let to_item_id: u32 = u16::decode(buf)?.into();
+                    let to_item_id: u32 = u16::decode(&mut body)?.into();
                     to_item_ids.push(to_item_id);
                 }
                 let reference = Reference {
@@ -50,14 +54,12 @@ impl AtomExt for Iref {
                 };
                 references.push(reference);
             } else {
-                let box_len = u32::decode(buf)?;
-                bytes_remaining -= box_len as usize;
-                let reference_type = FourCC::decode(buf)?;
-                let from_item_id: u32 = u32::decode(buf)?;
-                let reference_count: u16 = u16::decode(buf)?;
+                let reference_type = FourCC::decode(&mut body)?;
+                let from_item_id: u32 = u32::decode(&mut body)?;
+                let reference_count: u16 = u16::decode(&mut body)?;
                 let mut to_item_ids: Vec<u32> = vec![];
                 for _ in 0..reference_count {
-                    let to_item_id: u32 = u32::decode(buf)?;
+                    let to_item_id: u32 = u32::decode(&mut body)?;
                     to_item_ids.push(to_item_id);
                 }
                 let reference = Reference {
@@ -67,6 +69,11 @@ impl AtomExt for Iref {
                 };
                 references.push(reference);
             }
+
+            if body.has_remaining() {
+                return Err(Error::InvalidSize);
+            }
+            buf.advance(body_len);
         }
         Ok(Iref { references })
     }
@@ -109,5 +116,45 @@ impl AtomExt for Iref {
             }
         }
         Ok(IrefExt { version })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn oversized_nested_reference_returns_error() {
+        let body: &[u8] = &[
+            0x00, 0x00, 0x00, 0x20, // nested box length exceeds the iref body
+            b'd', b'i', b'm', b'g', // reference_type
+            0x00, 0x01, // from_item_id
+            0x00, 0x00, // reference_count
+        ];
+
+        assert!(matches!(
+            Iref::decode_body_ext(
+                &mut std::io::Cursor::new(body),
+                IrefExt {
+                    version: IrefVersion::V0,
+                },
+            ),
+            Err(Error::InvalidSize)
+        ));
+    }
+
+    #[test]
+    fn nested_reference_smaller_than_header_returns_error() {
+        let body: &[u8] = &[0x00, 0x00, 0x00, 0x03];
+
+        assert!(matches!(
+            Iref::decode_body_ext(
+                &mut std::io::Cursor::new(body),
+                IrefExt {
+                    version: IrefVersion::V0,
+                },
+            ),
+            Err(Error::InvalidSize)
+        ));
     }
 }

--- a/src/moov/trak/mdia/minf/stbl/subs.rs
+++ b/src/moov/trak/mdia/minf/stbl/subs.rs
@@ -116,8 +116,7 @@ impl AtomExt for Subs {
                 };
                 let priority = u8::decode(buf)?;
                 let discardable = u8::decode(buf)? == 1;
-                let codec_specific_parameters = buf.slice(4).to_vec();
-                buf.advance(4);
+                let codec_specific_parameters = <[u8; 4]>::decode(buf)?.to_vec();
                 subsamples.push(SubsSubsample {
                     size,
                     priority,
@@ -205,6 +204,30 @@ mod tests {
                 }],
             }
         )
+    }
+
+    #[test]
+    fn subs_truncated_codec_parameters_return_error() {
+        let body: &[u8] = &[
+            0x00, 0x00, 0x00, 0x01, // entry_count
+            0x00, 0x00, 0x00, 0x01, // sample_delta
+            0x00, 0x01, // subsample_count
+            0x00, 0x01, // subsample_size
+            0x00, // priority
+            0x00, // discardable
+            0x00, 0x00, 0x00, // truncated codec_specific_parameters
+        ];
+
+        assert!(matches!(
+            Subs::decode_body_ext(
+                &mut Cursor::new(body),
+                SubsExt {
+                    version: SubsVersion::V0,
+                    flags: [0; 3],
+                },
+            ),
+            Err(Error::OutOfBounds)
+        ));
     }
 
     // This example was taken from:


### PR DESCRIPTION
Fixes #179.

## What changed

- Decode the four-byte `subs` codec-specific parameters through the checked decoding path, returning an error for truncated input.
- Validate nested `iref` box sizes before slicing and constrain each reference decode to its declared box body.
- Return `Error::MissingContent` when encoding version 0 or `mime` `infe` entries without their required content type.
- Add regression tests for truncated `subs` data, invalid `iref` sizes, and both invalid `infe` encoder states.

## Why

These paths previously trusted attacker-controlled lengths or unwrapped optional fields. Malformed media could therefore panic, underflow, or loop instead of returning a normal parse/encode error.

The `iloc` size validation and unsupported `infe` version 1 handling described in the issue were already fixed on `main`; this PR addresses the remaining cases.

## Validation

- `cargo test --all-features` (244 tests passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all`
- `git diff --check`
