### PR TITLE
vpcc: validate chroma subsampling on encode

### DIFF
--- a/src/moov/trak/mdia/minf/stbl/stsd/vp9/vpcc.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/vp9/vpcc.rs
@@ -52,10 +52,14 @@ impl AtomExt for VpcC {
     }
 
     fn encode_body_ext<B: BufMut>(&self, buf: &mut B) -> Result<VpccExt> {
+        if self.chroma_subsampling > 0x07 {
+            return Err(Error::InvalidSize);
+        }
+
         self.profile.encode(buf)?;
         self.level.encode(buf)?;
         ((self.bit_depth << 4)
-            | (self.chroma_subsampling << 1)
+            | ((self.chroma_subsampling & 0x07) << 1)
             | (self.video_full_range_flag as u8))
             .encode(buf)?;
         self.color_primaries.encode(buf)?;
@@ -115,5 +119,18 @@ mod tests {
             let decoded = VpcC::decode(&mut buf).unwrap();
             assert_eq!(decoded, expected);
         }
+    }
+
+    #[test]
+    fn test_vpcc_rejects_invalid_chroma_subsampling() {
+        let vpcc = VpcC {
+            chroma_subsampling: 8,
+            ..VpcC::default()
+        };
+
+        assert!(matches!(
+            vpcc.encode(&mut Vec::new()),
+            Err(Error::InvalidSize)
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- reject `chroma_subsampling` values that do not fit the three-bit `vpcC` field
- mask the field defensively when packing it
- add regression coverage for an out-of-range value

## Why

PR #168 corrected decoding to use all three `chromaSubsampling` bits. Encoding still accepted values above 7, allowing those bits to bleed into the adjacent `bit_depth` field and produce a corrupt codec configuration.

This completes the remaining encoder hardening identified in #193. Invalid caller input now returns `Error::InvalidSize` instead of silently corrupting the packed byte.

## Validation

- `cargo test --all-targets` (237 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- `git diff --check`

Closes #193.
