### PR TITLE
Validate typed atom kinds and preserve dref entries

### DIFF
--- a/src/atom.rs
+++ b/src/atom.rs
@@ -49,6 +49,10 @@ impl<T: Atom> DecodeMaybe for T {
             None => return Ok(None),
         };
 
+        if header.kind != T::KIND {
+            return Err(Error::UnexpectedBox(header.kind));
+        }
+
         let size = header.size.unwrap_or(buf.remaining());
         if size > buf.remaining() {
             return Ok(None);
@@ -85,6 +89,10 @@ impl<T: Atom> ReadFrom for Option<T> {
             Some(header) => header,
             None => return Ok(None),
         };
+
+        if header.kind != T::KIND {
+            return Err(Error::UnexpectedBox(header.kind));
+        }
 
         let body = &mut header.read_body(r)?;
 
@@ -222,3 +230,24 @@ macro_rules! nested {
 }
 
 pub(crate) use nested;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    const FTYP_BODY_TAGGED_AS_MOOV: &[u8] = b"\0\0\0\x14mooviso6\0\0\x02\0mp41";
+
+    #[test]
+    fn typed_decode_rejects_unexpected_box() {
+        let err = Ftyp::decode(&mut Cursor::new(FTYP_BODY_TAGGED_AS_MOOV)).unwrap_err();
+        assert!(matches!(err, Error::UnexpectedBox(kind) if kind == Moov::KIND));
+    }
+
+    #[test]
+    fn typed_read_from_rejects_unexpected_box() {
+        let err =
+            <Ftyp as ReadFrom>::read_from(&mut Cursor::new(FTYP_BODY_TAGGED_AS_MOOV)).unwrap_err();
+        assert!(matches!(err, Error::UnexpectedBox(kind) if kind == Moov::KIND));
+    }
+}

--- a/src/meta/iinf.rs
+++ b/src/meta/iinf.rs
@@ -348,7 +348,7 @@ mod tests {
 
         assert!(matches!(
             fuzz_result,
-            Err(Error::Unsupported("infe version 1 extensions"))
+            Err(Error::UnexpectedBox(kind)) if kind == FourCC::new(b"\0\0A\x80")
         ));
     }
 }

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -154,9 +154,10 @@ mod tests {
         expected.push(Pitm { item_id: 3 });
         expected.push(Dinf {
             dref: Dref {
-                urls: vec![Url {
+                entries: vec![Url {
                     location: "".into(),
-                }],
+                }
+                .into()],
             },
         });
         expected.push(Iloc {

--- a/src/moov/mod.rs
+++ b/src/moov/mod.rs
@@ -185,7 +185,7 @@ mod test {
                             }),
                             dinf: Dinf {
                                 dref: Dref {
-                                    urls: vec![Url::default()]
+                                    entries: vec![Url::default().into()]
                                 }
                             },
                             stbl: Stbl {

--- a/src/moov/trak/mdia/minf/dinf/dref/mod.rs
+++ b/src/moov/trak/mdia/minf/dinf/dref/mod.rs
@@ -1,12 +1,83 @@
 mod url;
+mod urn;
 pub use url::*;
+pub use urn::*;
 
 use crate::*;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Dref {
-    pub urls: Vec<Url>,
+    pub entries: Vec<DrefEntry>,
+}
+
+/// An entry in a data reference box.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
+pub enum DrefEntry {
+    Url(Url),
+    Urn(Urn),
+    Unknown(FourCC, Vec<u8>),
+}
+
+impl DrefEntry {
+    pub fn kind(&self) -> FourCC {
+        match self {
+            Self::Url(_) => Url::KIND,
+            Self::Urn(_) => Urn::KIND,
+            Self::Unknown(kind, _) => *kind,
+        }
+    }
+}
+
+impl Decode for DrefEntry {
+    fn decode<B: Buf>(buf: &mut B) -> Result<Self> {
+        let header = Header::decode(buf)?;
+        let size = header.size.unwrap_or(buf.remaining());
+        if size > buf.remaining() {
+            return Err(Error::OutOfBounds);
+        }
+
+        match header.kind {
+            kind if kind == Url::KIND => Url::decode_atom(&header, buf).map(Self::Url),
+            kind if kind == Urn::KIND => Urn::decode_atom(&header, buf).map(Self::Urn),
+            kind => {
+                let data = Vec::decode(&mut buf.slice(size))?;
+                buf.advance(size);
+                Ok(Self::Unknown(kind, data))
+            }
+        }
+    }
+}
+
+impl Encode for DrefEntry {
+    fn encode<B: BufMut>(&self, buf: &mut B) -> Result<()> {
+        match self {
+            Self::Url(url) => url.encode(buf),
+            Self::Urn(urn) => urn.encode(buf),
+            Self::Unknown(kind, data) => {
+                Header {
+                    kind: *kind,
+                    size: Some(data.len()),
+                }
+                .encode(buf)?;
+                data.encode(buf)
+            }
+        }
+    }
+}
+
+impl From<Url> for DrefEntry {
+    fn from(url: Url) -> Self {
+        Self::Url(url)
+    }
+}
+
+impl From<Urn> for DrefEntry {
+    fn from(urn: Urn) -> Self {
+        Self::Urn(urn)
+    }
 }
 
 impl AtomExt for Dref {
@@ -16,23 +87,59 @@ impl AtomExt for Dref {
 
     fn decode_body_ext<B: Buf>(buf: &mut B, _ext: ()) -> Result<Self> {
         let entry_count = u32::decode(buf)?;
-        let mut urls = Vec::new();
+        let mut entries = Vec::new();
 
         for _ in 0..entry_count {
-            let url = Url::decode(buf)?;
-            urls.push(url);
+            entries.push(DrefEntry::decode(buf)?);
         }
 
-        Ok(Dref { urls })
+        Ok(Dref { entries })
     }
 
     fn encode_body_ext<B: BufMut>(&self, buf: &mut B) -> Result<()> {
-        (self.urls.len() as u32).encode(buf)?;
+        let entry_count =
+            u32::try_from(self.entries.len()).map_err(|_| Error::TooLarge(Self::KIND))?;
+        entry_count.encode(buf)?;
 
-        for url in &self.urls {
-            url.encode(buf)?;
+        for entry in &self.entries {
+            entry.encode(buf)?;
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    const ENCODED_URN_AND_UNKNOWN: &[u8] = &[
+        0, 0, 0, 48, b'd', b'r', b'e', b'f', 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 21, b'u', b'r', b'n',
+        b' ', 0, 0, 0, 0, b'n', b'a', b'm', b'e', 0, b'l', b'o', b'c', 0, 0, 0, 0, 11, b'a', b'b',
+        b'c', b'd', 1, 2, 3,
+    ];
+
+    #[test]
+    fn decode_and_preserve_urn_and_unknown_entries() {
+        let dref = Dref::decode(&mut Cursor::new(ENCODED_URN_AND_UNKNOWN)).unwrap();
+
+        assert_eq!(
+            dref,
+            Dref {
+                entries: vec![
+                    Urn {
+                        name: "name".into(),
+                        location: "loc".into(),
+                    }
+                    .into(),
+                    DrefEntry::Unknown(FourCC::new(b"abcd"), vec![1, 2, 3]),
+                ],
+            }
+        );
+
+        let mut encoded = Vec::new();
+        dref.encode(&mut encoded).unwrap();
+        assert_eq!(encoded, ENCODED_URN_AND_UNKNOWN);
     }
 }

--- a/src/moov/trak/mdia/minf/dinf/dref/urn.rs
+++ b/src/moov/trak/mdia/minf/dinf/dref/urn.rs
@@ -1,0 +1,34 @@
+use crate::*;
+
+ext! {
+    name: Urn,
+    versions: [0],
+    flags: {}
+}
+
+/// A name-based data reference and its location.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Urn {
+    pub name: String,
+    pub location: String,
+}
+
+impl AtomExt for Urn {
+    type Ext = UrnExt;
+
+    const KIND_EXT: FourCC = FourCC::new(b"urn ");
+
+    fn decode_body_ext<B: Buf>(buf: &mut B, _ext: UrnExt) -> Result<Self> {
+        Ok(Self {
+            name: String::decode(buf)?,
+            location: String::decode(buf)?,
+        })
+    }
+
+    fn encode_body_ext<B: BufMut>(&self, buf: &mut B) -> Result<UrnExt> {
+        self.name.as_str().encode(buf)?;
+        self.location.as_str().encode(buf)?;
+        Ok(UrnExt::default())
+    }
+}

--- a/src/test/av1.rs
+++ b/src/test/av1.rs
@@ -104,9 +104,10 @@ fn av1() {
                         }),
                         dinf: Dinf {
                             dref: Dref {
-                                urls: vec![Url {
+                                entries: vec![Url {
                                     location: "".into()
-                                }]
+                                }
+                                .into()]
                             }
                         },
                         stbl: Stbl {

--- a/src/test/bbb.rs
+++ b/src/test/bbb.rs
@@ -69,9 +69,9 @@ fn bbb() {
                         .into(),
                         dinf: Dinf {
                             dref: Dref {
-                                urls: vec![Url {
+                                entries: vec![Url {
                                     location: "".into(),
-                                }],
+                                }.into()],
                             },
                         },
                         stbl: Stbl {
@@ -150,9 +150,9 @@ fn bbb() {
                         }),
                         dinf: Dinf {
                             dref: Dref {
-                                urls: vec![Url {
+                                entries: vec![Url {
                                     location: "".into(),
-                                }],
+                                }.into()],
                             },
                         },
                         stbl: Stbl {

--- a/src/test/esds.rs
+++ b/src/test/esds.rs
@@ -69,9 +69,9 @@ fn esds() {
                         .into(),
                         dinf: Dinf {
                             dref: Dref {
-                                urls: vec![Url {
+                                entries: vec![Url {
                                     location: "".into(),
-                                }],
+                                }.into()],
                             },
                         },
                         stbl: Stbl {
@@ -150,9 +150,9 @@ fn esds() {
                         }),
                         dinf: Dinf {
                             dref: Dref {
-                                urls: vec![Url {
+                                entries: vec![Url {
                                     location: "".into(),
-                                }],
+                                }.into()],
                             },
                         },
                         stbl: Stbl {

--- a/src/test/flac.rs
+++ b/src/test/flac.rs
@@ -93,9 +93,10 @@ fn flac() {
                         smhd: Some(Smhd { balance: 0.into() }),
                         dinf: Dinf {
                             dref: Dref {
-                                urls: vec![Url {
+                                entries: vec![Url {
                                     location: "".into()
-                                }]
+                                }
+                                .into()]
                             }
                         },
                         stbl: Stbl {

--- a/src/test/h264.rs
+++ b/src/test/h264.rs
@@ -109,7 +109,7 @@ fn avcc_ext() {
                         }),
                         dinf: Dinf {
                             dref: Dref {
-                                urls: vec![Url::default()],
+                                entries: vec![Url::default().into()],
                             },
                         },
                         stbl: Stbl {
@@ -224,7 +224,7 @@ fn avcc_ext() {
                         smhd: Some(Smhd::default()),
                         dinf: Dinf {
                             dref: Dref {
-                                urls: vec![Url::default()],
+                                entries: vec![Url::default().into()],
                             },
                         },
                         stbl: Stbl {

--- a/src/test/hevc.rs
+++ b/src/test/hevc.rs
@@ -99,9 +99,10 @@ fn hevc() {
                         }),
                         dinf: Dinf {
                             dref: Dref {
-                                urls: vec![Url {
+                                entries: vec![Url {
                                     location: "".to_string()
-                                }]
+                                }
+                                .into()]
                             }
                         },
                         stbl: Stbl {

--- a/src/test/libavif_anim.rs
+++ b/src/test/libavif_anim.rs
@@ -210,9 +210,10 @@ fn av1_anim() {
                         }),
                         dinf: Dinf {
                             dref: Dref {
-                                urls: vec![Url {
+                                entries: vec![Url {
                                     location: "".into()
-                                }]
+                                }
+                                .into()]
                             }
                         },
                         stbl: Stbl {

--- a/src/test/uncompressed.rs
+++ b/src/test/uncompressed.rs
@@ -93,9 +93,10 @@ fn uncompressed() {
                         }),
                         dinf: Dinf {
                             dref: Dref {
-                                urls: vec![Url {
+                                entries: vec![Url {
                                     location: "".into()
-                                }],
+                                }
+                                .into()],
                             }
                         },
                         stbl: Stbl {

--- a/src/test/vp9.rs
+++ b/src/test/vp9.rs
@@ -124,9 +124,10 @@ fn vp9() {
                         }),
                         dinf: Dinf {
                             dref: Dref {
-                                urls: vec![Url {
+                                entries: vec![Url {
                                     location: "".to_string()
-                                }]
+                                }
+                                .into()]
                             }
                         },
                         stbl: Stbl {

--- a/src/tokio/atom.rs
+++ b/src/tokio/atom.rs
@@ -28,6 +28,10 @@ impl<T: Atom> AsyncReadFrom for Option<T> {
             None => return Ok(None),
         };
 
+        if header.kind != T::KIND {
+            return Err(Error::UnexpectedBox(header.kind));
+        }
+
         let mut buf = header.read_body_tokio(r).await?;
 
         let atom = match T::decode_body(&mut buf) {


### PR DESCRIPTION
Fixes #183

## Summary

- validate typed `Decode`, `ReadFrom`, and `AsyncReadFrom` paths against the atom FourCC before decoding the body
- replace `Dref.urls` with ordered `Dref.entries` supporting `url `, `urn `, and opaque unknown entries
- preserve unknown data-reference payloads and FourCCs during round trips
- add regression coverage for mismatched typed decoding and mixed `dref` entries

## Root cause

The generic typed convenience implementations decoded `T::decode_body` without first checking `header.kind == T::KIND`. `Dref` also decoded every child directly as `Url`, so valid `urn ` entries and unknown children could be silently reinterpreted and re-encoded as `url `.

## API impact

`Dref { urls: Vec<Url> }` becomes `Dref { entries: Vec<DrefEntry> }`. Existing URL entries can be constructed with `Url::default().into()`.

## Validation

- `cargo test --all-features` (239 unit tests and 3 doc tests)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
