### PR TITLE
vmhd: encode required FullBox flags value

### DIFF
--- a/src/moov/trak/mdia/minf/vmhd.rs
+++ b/src/moov/trak/mdia/minf/vmhd.rs
@@ -1,5 +1,19 @@
 use crate::*;
 
+#[derive(Default)]
+pub(crate) struct VmhdExt;
+
+impl Ext for VmhdExt {
+    fn encode(&self) -> Result<u32> {
+        // ISO/IEC 14496-12 requires vmhd to use version 0 and flags 1.
+        Ok(1)
+    }
+
+    fn decode(_: u32) -> Result<Self> {
+        Ok(Self)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Vmhd {
@@ -16,11 +30,11 @@ pub struct RgbColor {
 }
 
 impl AtomExt for Vmhd {
-    type Ext = ();
+    type Ext = VmhdExt;
 
     const KIND_EXT: FourCC = FourCC::new(b"vmhd");
 
-    fn decode_body_ext<B: Buf>(buf: &mut B, _ext: ()) -> Result<Self> {
+    fn decode_body_ext<B: Buf>(buf: &mut B, _ext: VmhdExt) -> Result<Self> {
         let graphics_mode = u16::decode(buf)?;
         let op_color = RgbColor {
             red: u16::decode(buf)?,
@@ -34,13 +48,13 @@ impl AtomExt for Vmhd {
         })
     }
 
-    fn encode_body_ext<B: BufMut>(&self, buf: &mut B) -> Result<()> {
+    fn encode_body_ext<B: BufMut>(&self, buf: &mut B) -> Result<VmhdExt> {
         self.graphics_mode.encode(buf)?;
         self.op_color.red.encode(buf)?;
         self.op_color.green.encode(buf)?;
         self.op_color.blue.encode(buf)?;
 
-        Ok(())
+        Ok(VmhdExt)
     }
 }
 
@@ -48,8 +62,13 @@ impl AtomExt for Vmhd {
 mod tests {
     use super::*;
 
+    const ENCODED_VMHD: &[u8] = &[
+        0x00, 0x00, 0x00, 0x14, b'v', b'm', b'h', b'd', 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
+
     #[test]
-    fn test_vmhd() {
+    fn test_vmhd_encode() {
         let expected = Vmhd {
             graphics_mode: 0,
             op_color: RgbColor {
@@ -61,8 +80,22 @@ mod tests {
         let mut buf = Vec::new();
         expected.encode(&mut buf).unwrap();
 
-        let mut buf = buf.as_ref();
+        assert_eq!(buf.as_slice(), ENCODED_VMHD);
+    }
+
+    #[test]
+    fn test_vmhd_decode() {
+        let mut buf = std::io::Cursor::new(ENCODED_VMHD);
         let decoded = Vmhd::decode(&mut buf).unwrap();
+
+        let expected = Vmhd {
+            graphics_mode: 0,
+            op_color: RgbColor {
+                red: 0,
+                green: 0,
+                blue: 0,
+            },
+        };
         assert_eq!(decoded, expected);
     }
 }


### PR DESCRIPTION
## Summary

- encode `vmhd` with the spec-required FullBox flags value `0x000001`
- add exact-byte encode and decode regression tests
- preserve permissive decoding behavior for existing inputs

## Background

`Vmhd` used the unit `Ext` implementation, which always encoded version 0 and flags 0. This silently normalized compliant `vmhd` atoms to a non-conforming flags value during re-encoding.

The `url ` concern reported in the issue is already fixed on `main` and covered by existing tests for both self-contained and external locations.

## Validation

- `just check`
- `just test` (237 tests passed)

Closes #188
