### PR TITLE
Preserve buffers when decode_maybe needs more data

### DIFF
--- a/src/any.rs
+++ b/src/any.rs
@@ -37,16 +37,21 @@ macro_rules! any {
 
         impl DecodeMaybe for Any {
             fn decode_maybe<B: Buf>(buf: &mut B) -> Result<Option<Self>> {
-                let header = match Header::decode_maybe(buf)? {
+                // Decode the header from a view so an incomplete atom leaves
+                // the caller's buffer untouched.
+                let remaining = buf.remaining();
+                let mut peek = buf.slice(remaining);
+                let header = match Header::decode_maybe(&mut peek)? {
                     Some(header) => header,
                     None => return Ok(None),
                 };
 
-                let size = header.size.unwrap_or(buf.remaining());
-                if size > buf.remaining() {
+                let size = header.size.unwrap_or(peek.remaining());
+                if size > peek.remaining() {
                     return Ok(None);
                 }
 
+                buf.advance(remaining - peek.remaining());
                 Ok(Some(Self::decode_atom(&header, buf)?))
             }
         }
@@ -379,5 +384,20 @@ impl ReadAtom for Any {
     fn read_atom<R: Read + ?Sized>(header: &Header, r: &mut R) -> Result<Self> {
         let body = &mut header.read_body(r)?;
         Any::decode_atom(header, body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PARTIAL_FTYP: &[u8] = b"\0\0\0\x14ftypisom";
+
+    #[test]
+    fn decode_maybe_preserves_incomplete_atom() {
+        let mut buf = PARTIAL_FTYP;
+
+        assert!(Any::decode_maybe(&mut buf).unwrap().is_none());
+        assert_eq!(buf, PARTIAL_FTYP);
     }
 }

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -44,16 +44,21 @@ impl<T: Atom> Decode for T {
 
 impl<T: Atom> DecodeMaybe for T {
     fn decode_maybe<B: Buf>(buf: &mut B) -> Result<Option<Self>> {
-        let header = match Header::decode_maybe(buf)? {
+        // Decode the header from a view so an incomplete atom leaves the
+        // caller's buffer untouched.
+        let remaining = buf.remaining();
+        let mut peek = buf.slice(remaining);
+        let header = match Header::decode_maybe(&mut peek)? {
             Some(header) => header,
             None => return Ok(None),
         };
 
-        let size = header.size.unwrap_or(buf.remaining());
-        if size > buf.remaining() {
+        let size = header.size.unwrap_or(peek.remaining());
+        if size > peek.remaining() {
             return Ok(None);
         }
 
+        buf.advance(remaining - peek.remaining());
         let body = &mut buf.slice(size);
 
         let atom = match Self::decode_body(body) {

--- a/src/ftyp.rs
+++ b/src/ftyp.rs
@@ -51,4 +51,13 @@ mod tests {
         let result = Ftyp::decode(&mut buf.as_slice()).expect("failed to decode");
         assert_eq!(decoded, result);
     }
+
+    #[test]
+    fn decode_maybe_preserves_incomplete_atom() {
+        const PARTIAL: &[u8] = b"\0\0\0\x14ftypisom";
+        let mut buf = PARTIAL;
+
+        assert!(Ftyp::decode_maybe(&mut buf).unwrap().is_none());
+        assert_eq!(buf, PARTIAL);
+    }
 }

--- a/src/moov/mod.rs
+++ b/src/moov/mod.rs
@@ -38,6 +38,21 @@ mod test {
     use super::*;
 
     #[test]
+    fn rejects_truncated_child_body() {
+        let mut encoded = Vec::new();
+        Moov::default().encode(&mut encoded).unwrap();
+
+        encoded.extend_from_slice(b"\0\0\0\x20trak");
+        let size = u32::try_from(encoded.len()).unwrap();
+        encoded[..4].copy_from_slice(&size.to_be_bytes());
+
+        assert!(matches!(
+            Moov::decode(&mut encoded.as_slice()),
+            Err(Error::UnderDecode(kind)) if kind == Moov::KIND
+        ));
+    }
+
+    #[test]
     fn test_meta() {
         const ENCODED: &[u8] = &[
             0x00, 0x00, 0x03, 0x3A, 0x6D, 0x6F, 0x6F, 0x76, 0x00, 0x00, 0x00, 0x6C, 0x6D, 0x76,


### PR DESCRIPTION
Fixes #181.

## What changed

- Decode atom headers through a non-consuming view in both the generic `Atom` and `Any` `DecodeMaybe` implementations.
- Advance the caller's buffer only after confirming the complete atom body is available.
- Add regression coverage for partial `ftyp` atoms through both decoder paths.
- Add coverage ensuring a nested atom with a header but truncated body is rejected.

## Why

`Header::decode_maybe` consumed a complete 8- or 16-byte header before the wrapper checked whether the declared body was buffered. Returning `Ok(None)` after that consumption desynchronized streaming callers that appended data and retried. Inside nested containers, the same behavior could silently discard a trailing child header with no body.

The decoder now preserves the original buffer whenever it returns `Ok(None)`, allowing streaming retries and causing truncated nested children to surface as `UnderDecode`.

## Validation

- `just check`
- `just test`
- 239 unit tests passed
- All-feature check, clippy with warnings denied, formatting, and dependency analysis passed
