### PR TITLE
Preserve QuickTime v2 audio sample entries

### DIFF
--- a/src/moov/trak/mdia/minf/stbl/stsd/ac3.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/ac3.rs
@@ -109,6 +109,7 @@ mod tests {
             Ac3 {
                 audio: Audio {
                     data_reference_index: 1,
+                    version: AudioVersion::V0,
                     channel_count: 2,
                     sample_size: 16,
                     sample_rate: 44100.into()
@@ -130,6 +131,7 @@ mod tests {
         let ac3 = Ac3 {
             audio: Audio {
                 data_reference_index: 1,
+                version: AudioVersion::V0,
                 channel_count: 2,
                 sample_size: 16,
                 sample_rate: 44100.into(),

--- a/src/moov/trak/mdia/minf/stbl/stsd/audio.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/audio.rs
@@ -1,13 +1,80 @@
 use crate::coding::{Decode, Encode};
-use crate::{Buf, BufMut, Error, FixedPoint, Result};
+use crate::{Buf, BufMut, Error, Result};
+
+/// Version-specific fields in an audio sample entry.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AudioVersion {
+    /// ISO/QuickTime version 0 sound sample description.
+    #[default]
+    V0,
+
+    /// QuickTime version 1 sound sample description.
+    V1 {
+        samples_per_packet: u32,
+        bytes_per_packet: u32,
+        bytes_per_frame: u32,
+        bytes_per_sample: u32,
+    },
+
+    /// QuickTime version 2 sound sample description.
+    V2 {
+        size_of_struct_only: u32,
+        always_7f000000: u32,
+        bits_per_channel: u32,
+        format_specific_flags: u32,
+        bytes_per_audio_packet: u32,
+        lpcm_frames_per_audio_packet: u32,
+    },
+}
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct Audio {
     pub data_reference_index: u16,
-    pub channel_count: u16,
+    pub version: AudioVersion,
+    pub channel_count: u32,
+    /// Legacy sample-size field.
+    ///
+    /// For version 2 entries, the authoritative value is the
+    /// `bits_per_channel` field in [`AudioVersion::V2`].
     pub sample_size: u16,
-    pub sample_rate: FixedPoint<u16>,
+    /// Sample rate in Hz.
+    ///
+    /// Version 0 and 1 entries store this as unsigned 16.16 fixed-point,
+    /// while version 2 entries store it as an IEEE-754 `f64`.
+    pub sample_rate: f64,
+}
+
+// Compare the encoded representation of the rate so Audio remains Eq even for
+// unusual version 2 values such as NaN, and so re-encoding preserves the bits.
+impl PartialEq for Audio {
+    fn eq(&self, other: &Self) -> bool {
+        self.data_reference_index == other.data_reference_index
+            && self.version == other.version
+            && self.channel_count == other.channel_count
+            && self.sample_size == other.sample_size
+            && self.sample_rate.to_bits() == other.sample_rate.to_bits()
+    }
+}
+
+impl Eq for Audio {}
+
+impl Audio {
+    fn decode_fixed_16_16(raw: u32) -> f64 {
+        f64::from(raw) / 65536.0
+    }
+
+    fn encode_fixed_16_16(value: f64) -> Result<u32> {
+        let scaled = value * 65536.0;
+        if !scaled.is_finite() || scaled < 0.0 || scaled > f64::from(u32::MAX) {
+            return Err(Error::Unsupported(
+                "sample rate does not fit unsigned 16.16 fixed-point",
+            ));
+        }
+
+        Ok(scaled.round() as u32)
+    }
 }
 
 impl Encode for Audio {
@@ -15,52 +82,193 @@ impl Encode for Audio {
         0u32.encode(buf)?; // reserved
         0u16.encode(buf)?; // reserved
         self.data_reference_index.encode(buf)?;
-        0u16.encode(buf)?; // version
-        0u16.encode(buf)?; // reserved
-        0u32.encode(buf)?; // reserved
-        self.channel_count.encode(buf)?;
-        self.sample_size.encode(buf)?;
-        0u32.encode(buf)?; // reserved
-        self.sample_rate.encode(buf)?;
+
+        let (version, channel_count, sample_size, compression_id, sample_rate) = match self.version
+        {
+            AudioVersion::V0 => (
+                0u16,
+                u16::try_from(self.channel_count)
+                    .map_err(|_| Error::Unsupported("version 0 channel count exceeds u16"))?,
+                self.sample_size,
+                0i16,
+                Self::encode_fixed_16_16(self.sample_rate)?,
+            ),
+            AudioVersion::V1 { .. } => (
+                1u16,
+                u16::try_from(self.channel_count)
+                    .map_err(|_| Error::Unsupported("version 1 channel count exceeds u16"))?,
+                self.sample_size,
+                -1i16,
+                Self::encode_fixed_16_16(self.sample_rate)?,
+            ),
+            // QuickTime mandates these placeholders for version 2. The
+            // authoritative values are written in the extension below.
+            AudioVersion::V2 { .. } => (2u16, 3, 16, -2i16, 0x0001_0000),
+        };
+
+        version.encode(buf)?;
+        0u16.encode(buf)?; // revision level
+        0u32.encode(buf)?; // vendor
+        channel_count.encode(buf)?;
+        sample_size.encode(buf)?;
+        compression_id.encode(buf)?;
+        0u16.encode(buf)?; // packet size
+        sample_rate.encode(buf)?;
+
+        match self.version {
+            AudioVersion::V0 => {}
+            AudioVersion::V1 {
+                samples_per_packet,
+                bytes_per_packet,
+                bytes_per_frame,
+                bytes_per_sample,
+            } => {
+                samples_per_packet.encode(buf)?;
+                bytes_per_packet.encode(buf)?;
+                bytes_per_frame.encode(buf)?;
+                bytes_per_sample.encode(buf)?;
+            }
+            AudioVersion::V2 {
+                size_of_struct_only,
+                always_7f000000,
+                bits_per_channel,
+                format_specific_flags,
+                bytes_per_audio_packet,
+                lpcm_frames_per_audio_packet,
+            } => {
+                size_of_struct_only.encode(buf)?;
+                self.sample_rate.to_bits().encode(buf)?;
+                self.channel_count.encode(buf)?;
+                always_7f000000.encode(buf)?;
+                bits_per_channel.encode(buf)?;
+                format_specific_flags.encode(buf)?;
+                bytes_per_audio_packet.encode(buf)?;
+                lpcm_frames_per_audio_packet.encode(buf)?;
+            }
+        }
 
         Ok(())
     }
 }
+
 impl Decode for Audio {
     fn decode<B: Buf>(buf: &mut B) -> Result<Self> {
         u32::decode(buf)?; // reserved
         u16::decode(buf)?; // reserved
         let data_reference_index = u16::decode(buf)?;
         let version = u16::decode(buf)?;
-        u16::decode(buf)?; // reserved
-        u32::decode(buf)?; // reserved
-        let channel_count = u16::decode(buf)?;
+        u16::decode(buf)?; // revision level
+        u32::decode(buf)?; // vendor
+        let legacy_channel_count = u16::decode(buf)?;
         let sample_size = u16::decode(buf)?;
-        u32::decode(buf)?; // pre-defined, reserved
-        let sample_rate = FixedPoint::decode(buf)?;
+        i16::decode(buf)?; // compression ID
+        u16::decode(buf)?; // packet size
+        let legacy_sample_rate = u32::decode(buf)?;
 
-        match version {
-            0 => {}
+        let (version, channel_count, sample_rate) = match version {
+            0 => (
+                AudioVersion::V0,
+                u32::from(legacy_channel_count),
+                Self::decode_fixed_16_16(legacy_sample_rate),
+            ),
             1 => {
-                // Quicktime sound sample description version 1.
-                u64::decode(buf)?;
-                u64::decode(buf)?;
+                let version = AudioVersion::V1 {
+                    samples_per_packet: u32::decode(buf)?,
+                    bytes_per_packet: u32::decode(buf)?,
+                    bytes_per_frame: u32::decode(buf)?,
+                    bytes_per_sample: u32::decode(buf)?,
+                };
+                (
+                    version,
+                    u32::from(legacy_channel_count),
+                    Self::decode_fixed_16_16(legacy_sample_rate),
+                )
             }
             2 => {
-                // Quicktime sound sample description version 2.
-                u32::decode(buf)?;
-                let _sample_rate = u64::decode(buf)?;
-                let _channel_count = u32::decode(buf)?;
-                <[u8; 20]>::decode(buf)?;
+                let size_of_struct_only = u32::decode(buf)?;
+                let sample_rate = f64::from_bits(u64::decode(buf)?);
+                let channel_count = u32::decode(buf)?;
+                let version = AudioVersion::V2 {
+                    size_of_struct_only,
+                    always_7f000000: u32::decode(buf)?,
+                    bits_per_channel: u32::decode(buf)?,
+                    format_specific_flags: u32::decode(buf)?,
+                    bytes_per_audio_packet: u32::decode(buf)?,
+                    lpcm_frames_per_audio_packet: u32::decode(buf)?,
+                };
+                (version, channel_count, sample_rate)
             }
             n => return Err(Error::UnknownQuicktimeVersion(n)),
-        }
+        };
 
         Ok(Self {
             data_reference_index,
+            version,
             channel_count,
             sample_size,
             sample_rate,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VERSION_2: &[u8] = &[
+        0, 0, 0, 0, 0, 0, // reserved
+        0, 1, // data reference index
+        0, 2, // version
+        0, 0, // revision level
+        0, 0, 0, 0, // vendor
+        0, 3, // placeholder channel count
+        0, 16, // placeholder sample size
+        0xff, 0xfe, // compression ID
+        0, 0, // packet size
+        0, 1, 0, 0, // placeholder sample rate (1.0)
+        0, 0, 0, 72, // size of struct only
+        0x40, 0xf7, 0x70, 0, 0, 0, 0, 0, // sample rate (96000.0)
+        0, 0, 0, 2, // channel count
+        0x7f, 0, 0, 0, // always 0x7f000000
+        0, 0, 0, 24, // bits per channel
+        0, 0, 0, 12, // signed integer, packed
+        0, 0, 0, 6, // bytes per audio packet
+        0, 0, 0, 1, // LPCM frames per audio packet
+    ];
+
+    #[test]
+    fn version_2_uses_authoritative_rate_and_channel_count() {
+        let mut buf = VERSION_2;
+        let audio = Audio::decode(&mut buf).unwrap();
+
+        assert_eq!(audio.channel_count, 2);
+        assert_eq!(audio.sample_rate, 96000.0);
+        assert!(matches!(audio.version, AudioVersion::V2 { .. }));
+    }
+
+    #[test]
+    fn version_2_roundtrips_without_becoming_version_0() {
+        let mut buf = VERSION_2;
+        let audio = Audio::decode(&mut buf).unwrap();
+        let mut encoded = Vec::new();
+        audio.encode(&mut encoded).unwrap();
+
+        assert_eq!(encoded, VERSION_2);
+    }
+
+    #[test]
+    fn version_0_rejects_a_rate_that_needs_version_2() {
+        let audio = Audio {
+            data_reference_index: 1,
+            version: AudioVersion::V0,
+            channel_count: 2,
+            sample_size: 24,
+            sample_rate: 96000.0,
+        };
+
+        assert!(matches!(
+            audio.encode(&mut Vec::new()),
+            Err(Error::Unsupported(_))
+        ));
     }
 }

--- a/src/moov/trak/mdia/minf/stbl/stsd/eac3.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/eac3.rs
@@ -164,6 +164,7 @@ mod tests {
             Eac3 {
                 audio: Audio {
                     data_reference_index: 1,
+                    version: AudioVersion::V0,
                     channel_count: 2,
                     sample_size: 16,
                     sample_rate: 44100.into()
@@ -190,6 +191,7 @@ mod tests {
         let eac3 = Eac3 {
             audio: Audio {
                 data_reference_index: 1,
+                version: AudioVersion::V0,
                 channel_count: 2,
                 sample_size: 16,
                 sample_rate: 44100.into(),
@@ -221,6 +223,7 @@ mod tests {
         let eac3 = Eac3 {
             audio: Audio {
                 data_reference_index: 1,
+                version: AudioVersion::V0,
                 channel_count: 6,
                 sample_size: 16,
                 sample_rate: 48000.into(),
@@ -258,6 +261,7 @@ mod tests {
         let eac3 = Eac3 {
             audio: Audio {
                 data_reference_index: 1,
+                version: AudioVersion::V0,
                 channel_count: 8,
                 sample_size: 16,
                 sample_rate: 48000.into(),
@@ -326,6 +330,7 @@ mod tests {
             Eac3 {
                 audio: Audio {
                     data_reference_index: 1,
+                    version: AudioVersion::V0,
                     channel_count: 2,
                     sample_size: 16,
                     sample_rate: 44100.into()

--- a/src/moov/trak/mdia/minf/stbl/stsd/mp4a/mod.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/mp4a/mod.rs
@@ -93,6 +93,7 @@ mod tests {
         let expected = Mp4a {
             audio: Audio {
                 data_reference_index: 1,
+                version: AudioVersion::V0,
                 channel_count: 2,
                 sample_size: 16,
                 sample_rate: 48000.into(),
@@ -147,6 +148,7 @@ mod tests {
     fn test_mp4a_quicktime_wave() {
         let audio = Audio {
             data_reference_index: 1,
+            version: AudioVersion::V0,
             channel_count: 2,
             sample_size: 16,
             sample_rate: 48000.into(),
@@ -212,6 +214,7 @@ mod tests {
         let expected = Mp4a {
             audio: Audio {
                 data_reference_index: 1,
+                version: AudioVersion::V0,
                 channel_count: 2,
                 sample_size: 16,
                 sample_rate: 48000.into(),

--- a/src/moov/trak/mdia/minf/stbl/stsd/pcm.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/pcm.rs
@@ -119,12 +119,15 @@ impl Pcm {
             let mut limited = buf.slice(size);
 
             if header.kind == Chnl::KIND {
+                let channel_count = u16::try_from(audio.channel_count).map_err(|_| {
+                    Error::Unsupported("channel count exceeds the chnl version 0 limit")
+                })?;
                 // Decode channel layout by using the channel count
                 // information. We cannot rely on the decode_body
                 // implementation of Atom for channel layout box.
                 chnl = Some(Chnl::decode_body_with_channel_count(
                     &mut limited,
-                    audio.channel_count,
+                    channel_count,
                 )?);
             } else {
                 match Any::decode_atom(&header, &mut limited)? {
@@ -171,9 +174,9 @@ impl Pcm {
     /// - `in24` / `in32`: big-endian integer, 24 / 32 bits
     /// - `fl32` / `fl64`: big-endian float, 32 / 64 bits
     /// - `s16l`: little-endian integer, 16 bits
-    /// - `lpcm`: QTFF format flags are only defined for version 2 sound sample
-    ///   descriptions, which are not decoded here; defaults to big-endian
-    ///   integer, `sample_size` bits
+    /// - `lpcm`: QTFF format flags are stored in version 2 sound sample
+    ///   descriptions and preserved in [`AudioVersion::V2`], but are not
+    ///   interpreted here; defaults to big-endian integer, `sample_size` bits
     ///
     /// Returns `None` for an unknown fourcc, or for an `ipcm`/`fpcm` entry
     /// missing its mandatory `pcmC` box (which
@@ -324,6 +327,7 @@ mod tests {
             fourcc: FourCC::new(b"fpcm"),
             audio: Audio {
                 data_reference_index: 1,
+                version: AudioVersion::V0,
                 channel_count: 2,
                 sample_size: 16,
                 sample_rate: 48000.into(),
@@ -360,6 +364,7 @@ mod tests {
             fourcc: FourCC::new(b"ipcm"),
             audio: Audio {
                 data_reference_index: 1,
+                version: AudioVersion::V0,
                 channel_count: 2,
                 sample_size: 16,
                 sample_rate: 48000.into(),
@@ -397,6 +402,7 @@ mod tests {
             fourcc: FourCC::new(b"fpcm"),
             audio: Audio {
                 data_reference_index: 1,
+                version: AudioVersion::V0,
                 channel_count: 2,
                 sample_size: 16,
                 sample_rate: 48000.into(),
@@ -438,6 +444,7 @@ mod tests {
             fourcc: FourCC::new(b"fpcm"),
             audio: Audio {
                 data_reference_index: 1,
+                version: AudioVersion::V0,
                 channel_count: 2,
                 sample_size: 16,
                 sample_rate: 48000.into(),
@@ -478,6 +485,7 @@ mod tests {
             fourcc: FourCC::new(b"fpcm"),
             audio: Audio {
                 data_reference_index: 1,
+                version: AudioVersion::V0,
                 channel_count: 2,
                 sample_size: 16,
                 sample_rate: 48000.into(),
@@ -514,6 +522,7 @@ mod tests {
         let pcm = Lpcm {
             audio: Audio {
                 data_reference_index: 1,
+                version: AudioVersion::V0,
                 channel_count: 2,
                 sample_size: 24,
                 sample_rate: 48000.into(),
@@ -544,9 +553,10 @@ mod tests {
         Ipcm {
             audio: Audio {
                 data_reference_index: 1,
+                version: AudioVersion::V0,
                 channel_count: 2,
                 sample_size: 24,
-                sample_rate: FixedPoint::new(48000, 0),
+                sample_rate: 48000.0,
             },
             pcmc: Some(PcmC {
                 big_endian: true,
@@ -611,9 +621,10 @@ mod tests {
             Twos {
                 audio: Audio {
                     data_reference_index: 1,
+                    version: AudioVersion::V0,
                     channel_count: 2,
                     sample_size: 16,
-                    sample_rate: FixedPoint::new(48000, 0),
+                    sample_rate: 48000.0,
                 },
                 pcmc: None,
                 chnl: None,
@@ -658,6 +669,7 @@ mod tests {
         let ipcm = Ipcm {
             audio: Audio {
                 data_reference_index: 1,
+                version: AudioVersion::V0,
                 channel_count: 2,
                 sample_size: 16,
                 sample_rate: 48000.into(),

--- a/src/test/bbb.rs
+++ b/src/test/bbb.rs
@@ -160,6 +160,7 @@ fn bbb() {
                                 codecs: vec![Mp4a {
                                     audio: Audio {
                                         data_reference_index: 1,
+                                        version: AudioVersion::V0,
                                         channel_count: 2,
                                         sample_size: 16,
                                         sample_rate: 44100.into(),

--- a/src/test/esds.rs
+++ b/src/test/esds.rs
@@ -160,6 +160,7 @@ fn esds() {
                                 codecs: vec![Mp4a {
                                     audio: Audio {
                                         data_reference_index: 1,
+                                        version: AudioVersion::V0,
                                         channel_count: 2,
                                         sample_size: 16,
                                         sample_rate: 44100.into(),

--- a/src/test/flac.rs
+++ b/src/test/flac.rs
@@ -103,6 +103,7 @@ fn flac() {
                                 codecs: vec![Flac {
                                     audio: Audio {
                                         data_reference_index: 1,
+                                        version: AudioVersion::V0,
                                         channel_count: 1,
                                         sample_size: 8,
                                         sample_rate: 44100.into(),

--- a/src/test/h264.rs
+++ b/src/test/h264.rs
@@ -232,6 +232,7 @@ fn avcc_ext() {
                                 codecs: vec![Mp4a {
                                     audio: Audio {
                                         data_reference_index: 1,
+                                        version: AudioVersion::V0,
                                         channel_count: 2,
                                         sample_size: 16,
                                         sample_rate: 48000.into(),


### PR DESCRIPTION
## Summary

- expose and preserve QuickTime audio sample entry versions and their version-specific fields
- decode version 2 sample rates and channel counts from the authoritative extension fields
- represent sample rates as `f64` and channel counts as `u32`, while validating the narrower version 0/1 encoding limits
- retain version 2 entries when re-encoding instead of emitting a version 0-shaped entry with placeholder values

## Root cause

Version 2 entries put placeholder values in the legacy prefix (`3` channels and `1 Hz`). The decoder read the authoritative `f64` sample rate and `u32` channel count from the version 2 extension but discarded them. Encoding then always emitted a version 0 entry, so decoded version 2 audio could be re-encoded with the placeholders as real values.

## Impact

High-rate and QuickTime PCM audio now reports its actual rate and channel count, including rates above 65535 Hz, and round-trips without losing the version 2 layout.

## Validation

- `cargo test --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #195
