### PR TITLE
Fix verified correctness issues from #197

### DIFF
--- a/src/any.rs
+++ b/src/any.rs
@@ -63,8 +63,8 @@ macro_rules! any {
                     Any::Unknown(_, data) => data.encode(buf),
                 }?;
 
-                let size: u32 = (buf.len() - start).try_into().map_err(|_| Error::TooLarge(self.kind()))?;
-                buf.set_slice(start, &size.to_be_bytes());
+                let len = buf.len() - start;
+                write_box_size(buf, start, len, self.kind())?;
 
                 Ok(())
             }

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -24,13 +24,10 @@ impl<T: Atom> Encode for T {
         Self::KIND.encode(buf)?;
         self.encode_body(buf)?;
 
-        // Update the size field
-        // TODO support sizes larger than u32 (4GB)
-        let size: u32 = (buf.len() - start)
-            .try_into()
-            .map_err(|_| Error::TooLarge(T::KIND))?;
-
-        buf.set_slice(start, &size.to_be_bytes());
+        // Update the size field, switching to the 64-bit largesize form if the
+        // box exceeds u32::MAX.
+        let len = buf.len() - start;
+        write_box_size(buf, start, len, T::KIND)?;
 
         Ok(())
     }

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -85,6 +85,11 @@ pub trait BufMut {
 
     // Set a slice at a position in the buffer.
     fn set_slice(&mut self, pos: usize, val: &[u8]);
+
+    // Insert a slice into the buffer at `pos`, shifting any existing bytes at or
+    // after `pos` toward the end. Used to retrofit the 8-byte 64-bit `largesize`
+    // field into a box header once we discover the body exceeds `u32::MAX`.
+    fn insert_slice(&mut self, pos: usize, val: &[u8]);
 }
 
 impl BufMut for Vec<u8> {
@@ -98,6 +103,10 @@ impl BufMut for Vec<u8> {
 
     fn set_slice(&mut self, pos: usize, val: &[u8]) {
         self[pos..pos + val.len()].copy_from_slice(val);
+    }
+
+    fn insert_slice(&mut self, pos: usize, val: &[u8]) {
+        self.splice(pos..pos, val.iter().copied());
     }
 }
 
@@ -113,6 +122,10 @@ impl<T: BufMut + ?Sized> BufMut for &mut T {
     fn set_slice(&mut self, pos: usize, val: &[u8]) {
         (**self).set_slice(pos, val);
     }
+
+    fn insert_slice(&mut self, pos: usize, val: &[u8]) {
+        (**self).insert_slice(pos, val);
+    }
 }
 
 #[cfg(feature = "bytes")]
@@ -127,5 +140,11 @@ impl BufMut for bytes::BytesMut {
 
     fn set_slice(&mut self, pos: usize, val: &[u8]) {
         self[pos..pos + val.len()].copy_from_slice(val);
+    }
+
+    fn insert_slice(&mut self, pos: usize, val: &[u8]) {
+        let tail = self.split_off(pos);
+        self.extend_from_slice(val);
+        self.unsplit(tail);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,6 +57,9 @@ pub enum Error {
     #[error("out of memory")]
     OutOfMemory,
 
+    #[error("value out of range")]
+    OutOfRange,
+
     #[error("reserved")]
     Reserved,
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -13,23 +13,60 @@ pub struct Header {
     pub size: Option<usize>,
 }
 
+/// Backfill the size field of a box that was encoded with an 8-byte header
+/// placeholder (a 4-byte size of `0` followed by the 4-byte kind) starting at
+/// `start`. `len` is the number of bytes written since `start` (header
+/// placeholder + body).
+///
+/// If the box fits in 32 bits the placeholder is simply overwritten. Otherwise
+/// the 64-bit `largesize` form is used: the size field becomes `1` and an 8-byte
+/// largesize is spliced in after the kind, growing the header to 16 bytes.
+pub(crate) fn write_box_size<B: BufMut>(
+    buf: &mut B,
+    start: usize,
+    len: usize,
+    kind: FourCC,
+) -> Result<()> {
+    match u32::try_from(len) {
+        Ok(size) => {
+            buf.set_slice(start, &size.to_be_bytes());
+        }
+        Err(_) => {
+            // The 16-byte largesize header replaces the 8-byte one, so the total
+            // box size is the current length plus the extra 8 bytes.
+            let total = (len as u64).checked_add(8).ok_or(Error::TooLarge(kind))?;
+            buf.insert_slice(start + 8, &total.to_be_bytes());
+            buf.set_slice(start, &1u32.to_be_bytes());
+        }
+    }
+    Ok(())
+}
+
 impl Encode for Header {
     fn encode<B: BufMut>(&self, buf: &mut B) -> Result<()> {
-        match self.size.map(|size| size + 8) {
-            Some(size) if size > u32::MAX as usize => {
-                1u32.encode(buf)?;
-                self.kind.encode(buf)?;
-
-                // Have to include the size of this extra field
-                ((size + 8) as u64).encode(buf)
-            }
-            Some(size) => {
-                (size as u32).encode(buf)?;
-                self.kind.encode(buf)
-            }
+        match self.size {
             None => {
                 0u32.encode(buf)?;
                 self.kind.encode(buf)
+            }
+            Some(size) => {
+                // Total box size including the 8-byte basic header.
+                let total = size.checked_add(8).ok_or(Error::TooLarge(self.kind))?;
+                if total <= u32::MAX as usize {
+                    (total as u32).encode(buf)?;
+                    self.kind.encode(buf)
+                } else {
+                    // Use the 64-bit largesize form: size==1, then an 8-byte
+                    // largesize covering the full 16-byte header plus the body.
+                    // (Only reachable on 64-bit targets, since a >4 GiB buffer
+                    // cannot exist on a 32-bit target.)
+                    1u32.encode(buf)?;
+                    self.kind.encode(buf)?;
+                    let large = (size as u64)
+                        .checked_add(16)
+                        .ok_or(Error::TooLarge(self.kind))?;
+                    large.encode(buf)
+                }
             }
         }
     }
@@ -45,7 +82,10 @@ impl Decode for Header {
             1 => {
                 // Read another 8 bytes
                 let size = u64::decode(buf)?;
-                Some(size.checked_sub(16).ok_or(Error::InvalidSize)? as usize)
+                let size = size.checked_sub(16).ok_or(Error::InvalidSize)?;
+                // On 32-bit targets a `as usize` cast would silently truncate,
+                // producing a misaligned parse instead of a clean error.
+                Some(usize::try_from(size).map_err(|_| Error::TooLarge(kind))?)
             }
             _ => Some(size.checked_sub(8).ok_or(Error::InvalidSize)? as usize),
         };
@@ -96,7 +136,8 @@ impl ReadFrom for Option<Header> {
                 let size = u64::from_be_bytes(buf);
                 let size = size.checked_sub(16).ok_or(Error::InvalidSize)?;
 
-                Some(size as usize)
+                // Avoid silent truncation of a 64-bit size on 32-bit targets.
+                Some(usize::try_from(size).map_err(|_| Error::TooLarge(kind))?)
             }
             _ => Some(size.checked_sub(8).ok_or(Error::InvalidSize)? as usize),
         };
@@ -159,5 +200,57 @@ impl Header {
         };
 
         Ok(Cursor::new(buf))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_largesize_round_trip() {
+        // A body just over u32::MAX must use the 64-bit largesize form. We only
+        // exercise the header itself (no body) to avoid a multi-GiB allocation.
+        let body_size = u32::MAX as usize + 1;
+        let header = Header {
+            kind: FourCC::new(b"mdat"),
+            size: Some(body_size),
+        };
+
+        let mut buf = Vec::new();
+        header.encode(&mut buf).unwrap();
+
+        // size==1 marker, kind, then an 8-byte largesize == body + 16-byte header.
+        assert_eq!(&buf[0..4], &1u32.to_be_bytes());
+        assert_eq!(&buf[4..8], b"mdat");
+        assert_eq!(
+            u64::from_be_bytes(buf[8..16].try_into().unwrap()),
+            body_size as u64 + 16
+        );
+
+        let decoded = Header::decode(&mut buf.as_slice()).unwrap();
+        assert_eq!(decoded.kind, header.kind);
+        assert_eq!(decoded.size, Some(body_size));
+    }
+
+    #[test]
+    fn write_box_size_switches_to_largesize() {
+        // Simulate a box whose encoded length just exceeds u32::MAX without
+        // actually allocating it: start with the 8-byte header placeholder and
+        // claim a large length.
+        let mut buf = vec![0u8; 8];
+        buf[4..8].copy_from_slice(b"mdat");
+        let len = u32::MAX as usize + 1; // pretend the body made us this big
+
+        write_box_size(&mut buf, 0, len, FourCC::new(b"mdat")).unwrap();
+
+        // 8 bytes should have been inserted after the kind.
+        assert_eq!(buf.len(), 16);
+        assert_eq!(&buf[0..4], &1u32.to_be_bytes());
+        assert_eq!(&buf[4..8], b"mdat");
+        assert_eq!(
+            u64::from_be_bytes(buf[8..16].try_into().unwrap()),
+            len as u64 + 8
+        );
     }
 }

--- a/src/meta/properties/irot.rs
+++ b/src/meta/properties/irot.rs
@@ -19,7 +19,9 @@ impl Atom for Irot {
     }
 
     fn encode_body<B: BufMut>(&self, buf: &mut B) -> Result<()> {
-        self.angle.encode(buf)
+        // Only the low 2 bits are meaningful; the upper 6 bits are reserved and
+        // masked off on decode, so mask here too for a symmetric round-trip.
+        (self.angle & 0x03).encode(buf)
     }
 }
 

--- a/src/mfra/mod.rs
+++ b/src/mfra/mod.rs
@@ -47,8 +47,23 @@ impl Atom for Mfra {
     }
 
     fn encode_body<B: BufMut>(&self, buf: &mut B) -> Result<()> {
+        let start = buf.len();
         self.tfra.iter().try_for_each(|x| x.encode(buf))?;
-        self.mfro.encode(buf)
+        let tfra_bytes = buf.len() - start;
+
+        // `mfro.parent_size` must equal the total size of the enclosing `mfra`
+        // box, so recompute it rather than trusting a possibly-stale stored
+        // value (e.g. after a `tfra` was modified). Seek-from-end readers rely
+        // on this to locate the start of the `mfra`.
+        //   mfra = 8-byte header + tfra bytes + 16-byte mfro box
+        let parent_size = 8usize
+            .checked_add(tfra_bytes)
+            .and_then(|n| n.checked_add(16))
+            .ok_or(Error::TooLarge(Self::KIND))?;
+        let mfro = Mfro {
+            parent_size: u32::try_from(parent_size).map_err(|_| Error::TooLarge(Self::KIND))?,
+        };
+        mfro.encode(buf)
     }
 }
 

--- a/src/mfra/tfra.rs
+++ b/src/mfra/tfra.rs
@@ -86,7 +86,7 @@ fn encode_variable_unsigned_int<B: BufMut>(
         0 => (value as u8).encode(buf),
         1 => (value as u16).encode(buf),
         2 => {
-            let v: u24 = value.try_into().expect("should have already been checked");
+            let v: u24 = value.try_into()?;
             v.encode(buf)
         }
         3 => value.encode(buf),

--- a/src/moov/trak/mdia/mdhd.rs
+++ b/src/moov/trak/mdia/mdhd.rs
@@ -6,7 +6,7 @@ ext! {
     flags: {}
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Mdhd {
     pub creation_time: u64,
@@ -14,6 +14,21 @@ pub struct Mdhd {
     pub timescale: u32,
     pub duration: u64,
     pub language: String,
+}
+
+impl Default for Mdhd {
+    fn default() -> Self {
+        Self {
+            creation_time: 0,
+            modification_time: 0,
+            timescale: 0,
+            duration: 0,
+            // "und" (undetermined) is the ISO 639-2 code for an unspecified
+            // language. An empty string is not representable in the packed
+            // 15-bit form and would not survive an encode/decode round-trip.
+            language: "und".to_string(),
+        }
+    }
 }
 
 impl AtomExt for Mdhd {
@@ -78,6 +93,17 @@ mod tests {
             duration: 30439936,
             language: String::from("und"),
         };
+        let mut buf = Vec::new();
+        expected.encode(&mut buf).unwrap();
+
+        let mut buf = buf.as_ref();
+        let decoded = Mdhd::decode(&mut buf).unwrap();
+        assert_eq!(decoded, expected);
+    }
+
+    #[test]
+    fn test_mdhd_default_round_trip() {
+        let expected = Mdhd::default();
         let mut buf = Vec::new();
         expected.encode(&mut buf).unwrap();
 

--- a/src/moov/trak/mdia/minf/stbl/stsd/av01.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/av01.rs
@@ -140,8 +140,18 @@ impl Atom for Av1c {
 
     fn encode_body<B: BufMut>(&self, buf: &mut B) -> Result<()> {
         0b1000_0001_u8.encode(buf)?;
+
+        // seq_profile is 3 bits and seq_level_idx_0 is 5 bits; out-of-range
+        // values would otherwise silently corrupt neighbouring fields.
+        if self.seq_profile > 0b111 || self.seq_level_idx_0 > 0b1_1111 {
+            return Err(Error::OutOfRange);
+        }
         ((self.seq_profile << 5) | self.seq_level_idx_0).encode(buf)?;
 
+        // chroma_sample_position occupies only the low 2 bits.
+        if self.chroma_sample_position > 0b11 {
+            return Err(Error::OutOfRange);
+        }
         (((self.seq_tier_0 as u8) << 7)
             | ((self.high_bitdepth as u8) << 6)
             | ((self.twelve_bit as u8) << 5)
@@ -152,7 +162,15 @@ impl Atom for Av1c {
             .encode(buf)?;
 
         if let Some(initial_presentation_delay) = self.initial_presentation_delay {
-            ((initial_presentation_delay - 1) | 0b0001_0000).encode(buf)?;
+            // The stored value is the real delay (1..=16); on the wire it is
+            // `delay - 1` in the low 4 bits, with bit 4 marking presence.
+            let minus_one = initial_presentation_delay
+                .checked_sub(1)
+                .ok_or(Error::OutOfRange)?;
+            if minus_one > 0b1111 {
+                return Err(Error::OutOfRange);
+            }
+            (minus_one | 0b0001_0000).encode(buf)?;
         } else {
             0b0000_0000_u8.encode(buf)?;
         }

--- a/src/moov/trak/mdia/minf/stbl/stsd/colr.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/colr.rs
@@ -54,7 +54,8 @@ impl Atom for Colr {
                 let colour_primaries = u16::decode(buf)?;
                 let transfer_characteristics = u16::decode(buf)?;
                 let matrix_coefficients = u16::decode(buf)?;
-                let full_range_flag = u8::decode(buf)? == 0x80;
+                // The high bit is full_range_flag; the low 7 bits are reserved.
+                let full_range_flag = u8::decode(buf)? & 0x80 != 0;
                 Ok(Colr::Nclx {
                     colour_primaries,
                     transfer_characteristics,

--- a/src/moov/trak/mdia/minf/stbl/stsd/eac3.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/eac3.rs
@@ -116,7 +116,23 @@ impl Atom for Ec3SpecificBox {
     }
 
     fn encode_body<B: BufMut>(&self, buf: &mut B) -> Result<()> {
-        let header = self.data_rate << 3 | self.substreams.len().saturating_sub(1) as u16;
+        // num_ind_sub is a 3-bit field encoding (count - 1), so there must be
+        // between 1 and 8 substreams. An empty vec would otherwise write a
+        // header claiming one substream while emitting none.
+        if self.substreams.is_empty() {
+            return Err(Error::MissingContent(
+                "dec3 requires at least one substream",
+            ));
+        }
+        if self.substreams.len() > 8 {
+            return Err(Error::OutOfRange);
+        }
+        // data_rate is a 13-bit field; larger values would overflow into
+        // num_ind_sub instead of being silently truncated.
+        if self.data_rate > 0x1FFF {
+            return Err(Error::OutOfRange);
+        }
+        let header = self.data_rate << 3 | (self.substreams.len() as u16 - 1);
         header.encode(buf)?;
         for substream in &self.substreams {
             // low bit is reserved = 0

--- a/src/moov/trak/mdia/minf/stbl/stsd/flac.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/flac.rs
@@ -48,17 +48,24 @@ pub enum FlacMetadataBlock {
         number_of_interchannel_samples: u64,
         md5_checksum: Vec<u8>,
     },
-    Padding,
-    Application,
-    SeekTable,
+    /// A padding block. The raw (typically all-zero) payload is retained so the
+    /// block round-trips instead of being silently dropped.
+    Padding(Vec<u8>),
+    Application(Vec<u8>),
+    SeekTable(Vec<u8>),
     VorbisComment {
         vendor_string: String,
         comments: Vec<String>,
     },
-    CueSheet,
-    Picture,
-    Reserved,
-    Forbidden,
+    CueSheet(Vec<u8>),
+    Picture(Vec<u8>),
+    /// A block whose type is in the reserved range (7..=126). The `block_type`
+    /// is retained so it can be re-emitted unchanged.
+    Reserved {
+        block_type: u8,
+        data: Vec<u8>,
+    },
+    Forbidden(Vec<u8>),
 }
 
 impl FlacMetadataBlock {
@@ -67,6 +74,22 @@ impl FlacMetadataBlock {
             true => (0x80 | block_type).encode(buf),
             false => block_type.encode(buf),
         }
+    }
+
+    /// Encode an opaque metadata block whose payload we retain verbatim.
+    fn encode_raw<B: BufMut>(
+        buf: &mut B,
+        block_type: u8,
+        is_last: bool,
+        data: &[u8],
+    ) -> Result<()> {
+        Self::encode_initial_byte(buf, block_type, is_last)?;
+        let length: u24 = (data.len() as u32)
+            .try_into()
+            .map_err(|_| Error::TooLarge(Dfla::KIND))?;
+        length.encode(buf)?;
+        data.encode(buf)?;
+        Ok(())
     }
     fn encode<B: BufMut>(&self, buf: &mut B, is_last: bool) -> Result<()> {
         match self {
@@ -105,9 +128,9 @@ impl FlacMetadataBlock {
                     .map_err(|_| Error::TooLarge(Dfla::KIND))?;
                 buf.set_slice(length_position - 3, &length.to_be_bytes());
             }
-            FlacMetadataBlock::Padding => { /* cannot write this yet */ }
-            FlacMetadataBlock::Application => { /* cannot write this yet */ }
-            FlacMetadataBlock::SeekTable => { /* cannot write this yet */ }
+            FlacMetadataBlock::Padding(data) => Self::encode_raw(buf, 1, is_last, data)?,
+            FlacMetadataBlock::Application(data) => Self::encode_raw(buf, 2, is_last, data)?,
+            FlacMetadataBlock::SeekTable(data) => Self::encode_raw(buf, 3, is_last, data)?,
             FlacMetadataBlock::VorbisComment {
                 vendor_string,
                 comments,
@@ -134,10 +157,12 @@ impl FlacMetadataBlock {
                     .map_err(|_| Error::TooLarge(Dfla::KIND))?;
                 buf.set_slice(length_position - 3, &length.to_be_bytes());
             }
-            FlacMetadataBlock::CueSheet => { /* cannot write this yet */ }
-            FlacMetadataBlock::Picture => { /* cannot write this yet */ }
-            FlacMetadataBlock::Reserved => { /* No way to write this */ }
-            FlacMetadataBlock::Forbidden => { /* No way to write this */ }
+            FlacMetadataBlock::CueSheet(data) => Self::encode_raw(buf, 5, is_last, data)?,
+            FlacMetadataBlock::Picture(data) => Self::encode_raw(buf, 6, is_last, data)?,
+            FlacMetadataBlock::Reserved { block_type, data } => {
+                Self::encode_raw(buf, *block_type, is_last, data)?
+            }
+            FlacMetadataBlock::Forbidden(data) => Self::encode_raw(buf, 127, is_last, data)?,
         }
         Ok(())
     }
@@ -223,14 +248,17 @@ impl AtomExt for Dfla {
             let block_data: Vec<u8> = Vec::decode_exact(buf, length as usize)?;
             let metadata_block = match block_type {
                 0 => parse_stream_info(&block_data)?,
-                1 => FlacMetadataBlock::Padding,
-                2 => FlacMetadataBlock::Application,
-                3 => FlacMetadataBlock::SeekTable,
+                1 => FlacMetadataBlock::Padding(block_data),
+                2 => FlacMetadataBlock::Application(block_data),
+                3 => FlacMetadataBlock::SeekTable(block_data),
                 4 => parse_vorbis_comment(&block_data)?,
-                5 => FlacMetadataBlock::CueSheet,
-                6 => FlacMetadataBlock::Picture,
-                7..=126 => FlacMetadataBlock::Reserved,
-                127 => FlacMetadataBlock::Forbidden,
+                5 => FlacMetadataBlock::CueSheet(block_data),
+                6 => FlacMetadataBlock::Picture(block_data),
+                7..=126 => FlacMetadataBlock::Reserved {
+                    block_type,
+                    data: block_data,
+                },
+                127 => FlacMetadataBlock::Forbidden(block_data),
                 _ => unreachable!("FLAC Metadata Block type is only 7 bits"),
             };
             metadata_blocks.push(metadata_block);
@@ -312,6 +340,34 @@ mod tests {
         dfla.encode(&mut buf).unwrap();
 
         assert_eq!(buf.as_slice(), ENCODED_DFLA);
+    }
+
+    #[test]
+    fn test_dfla_padding_round_trip() {
+        // A StreamInfo block followed by a trailing Padding block (as libFLAC
+        // typically emits). The padding must survive a decode/encode round-trip
+        // and carry the last-metadata-block flag.
+        let dfla = Dfla {
+            blocks: vec![
+                FlacMetadataBlock::StreamInfo {
+                    minimum_block_size: 4608,
+                    maximum_block_size: 4608,
+                    minimum_frame_size: 0u32.try_into().unwrap(),
+                    maximum_frame_size: 0u32.try_into().unwrap(),
+                    sample_rate: 44100,
+                    num_channels_minus_one: 1,
+                    bits_per_sample_minus_one: 15,
+                    number_of_interchannel_samples: 0,
+                    md5_checksum: vec![0; 16],
+                },
+                FlacMetadataBlock::Padding(vec![0; 8]),
+            ],
+        };
+
+        let mut buf = Vec::new();
+        dfla.encode(&mut buf).unwrap();
+        let decoded = Dfla::decode(&mut buf.as_ref()).unwrap();
+        assert_eq!(decoded, dfla);
     }
 
     // Streaminfo metadata block plus Vorbis Comment metadata block

--- a/src/moov/trak/mdia/minf/stbl/stsd/h264/avcc.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/h264/avcc.rs
@@ -34,11 +34,31 @@ impl Default for AvccExt {
     }
 }
 
+/// Whether an AVCDecoderConfigurationRecord with this `profile_idc` carries the
+/// chroma/bit-depth extension block. Per ISO/IEC 14496-15 the extension is
+/// present for these High-profile indications (note the real High 4:4:4
+/// Predictive value is 244; some older spec text erroneously listed 144).
+fn profile_has_ext(profile_idc: u8) -> bool {
+    matches!(
+        profile_idc,
+        100 | 110 | 122 | 144 | 244 | 44 | 83 | 86 | 118 | 128 | 138 | 139 | 134 | 135
+    )
+}
+
 impl Avcc {
     pub fn new(sps: &[u8], pps: &[u8]) -> Result<Self> {
         if sps.len() < 4 {
             return Err(Error::OutOfBounds);
         }
+
+        // High profiles require the extension block; supply spec-compliant
+        // defaults (4:2:0, 8-bit) rather than emitting a record that omits it.
+        // TODO This information could be parsed out of the SPS.
+        let ext = if profile_has_ext(sps[1]) {
+            Some(AvccExt::default())
+        } else {
+            None
+        };
 
         Ok(Self {
             configuration_version: 1,
@@ -48,9 +68,7 @@ impl Avcc {
             length_size: 4,
             sequence_parameter_sets: vec![sps.into()],
             picture_parameter_sets: vec![pps.into()],
-
-            // TODO This information could be parsed out of the SPS
-            ext: None,
+            ext,
         })
     }
 }
@@ -86,9 +104,12 @@ impl Atom for Avcc {
             picture_parameter_sets.push(nal);
         }
 
-        // NOTE: Many encoders/decoders skip this extended avcC part.
-        // It's profile specific, but we don't really care and will parse it if present.
-        let ext = if buf.has_remaining() {
+        // The extension block is only defined for High profiles. Gating on the
+        // profile (rather than on leftover bytes) avoids misparsing trailing
+        // padding after a Baseline record as a chroma/bit-depth extension.
+        // Its absence on a High-profile record is tolerated (some encoders omit
+        // it), in which case any stray trailing bytes surface as UnderDecode.
+        let ext = if profile_has_ext(avc_profile_indication) && buf.has_remaining() {
             let chroma_format = u8::decode(buf)? & 0x3;
             let bit_depth_luma_minus8 = u8::decode(buf)? & 0x7;
             let bit_depth_chroma_minus8 = u8::decode(buf)? & 0x7;
@@ -136,15 +157,26 @@ impl Atom for Avcc {
         };
         (length_size | 0xFC).encode(buf)?;
 
+        // numOfSequenceParameterSets is a 5-bit field (top 3 bits reserved).
+        if self.sequence_parameter_sets.len() > 0x1F {
+            return Err(Error::OutOfRange);
+        }
         (self.sequence_parameter_sets.len() as u8 | 0xE0).encode(buf)?;
         for sps in &self.sequence_parameter_sets {
-            (sps.len() as u16).encode(buf)?;
+            u16::try_from(sps.len())
+                .map_err(|_| Error::OutOfRange)?
+                .encode(buf)?;
             sps.encode(buf)?;
         }
 
-        (self.picture_parameter_sets.len() as u8).encode(buf)?;
+        // numOfPictureParameterSets is an 8-bit field.
+        u8::try_from(self.picture_parameter_sets.len())
+            .map_err(|_| Error::OutOfRange)?
+            .encode(buf)?;
         for pps in &self.picture_parameter_sets {
-            (pps.len() as u16).encode(buf)?;
+            u16::try_from(pps.len())
+                .map_err(|_| Error::OutOfRange)?
+                .encode(buf)?;
             pps.encode(buf)?;
         }
 
@@ -168,9 +200,13 @@ impl Atom for Avcc {
             )
             .map(|n| n | 0b11111000)?
             .encode(buf)?;
-            (ext.sequence_parameter_sets_ext.len() as u8).encode(buf)?;
+            u8::try_from(ext.sequence_parameter_sets_ext.len())
+                .map_err(|_| Error::OutOfRange)?
+                .encode(buf)?;
             for sps in &ext.sequence_parameter_sets_ext {
-                (sps.len() as u16).encode(buf)?;
+                u16::try_from(sps.len())
+                    .map_err(|_| Error::OutOfRange)?
+                    .encode(buf)?;
                 sps.encode(buf)?;
             }
         }

--- a/src/moov/trak/mdia/minf/stbl/stsd/hevc/hvcc.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/hevc/hvcc.rs
@@ -147,13 +147,21 @@ impl Atom for Hvcc {
         let length_size_minus_one = self.length_size_minus_one & 0b11;
         (constant_frame_rate | num_temporal_layers | temporal_id_nested | length_size_minus_one)
             .encode(buf)?;
-        (self.arrays.len() as u8).encode(buf)?;
+        // numOfArrays is 8 bits, numNalus is 16 bits, and each NAL length is 16
+        // bits; reject values that would silently truncate.
+        u8::try_from(self.arrays.len())
+            .map_err(|_| Error::OutOfRange)?
+            .encode(buf)?;
         for arr in &self.arrays {
             ((arr.nal_unit_type & 0b111111) | (u8::from(arr.completeness) << 7)).encode(buf)?;
-            (arr.nalus.len() as u16).encode(buf)?;
+            u16::try_from(arr.nalus.len())
+                .map_err(|_| Error::OutOfRange)?
+                .encode(buf)?;
 
             for nalu in &arr.nalus {
-                (nalu.len() as u16).encode(buf)?;
+                u16::try_from(nalu.len())
+                    .map_err(|_| Error::OutOfRange)?
+                    .encode(buf)?;
                 nalu.encode(buf)?;
             }
         }

--- a/src/moov/trak/mdia/minf/stbl/stsd/uncv.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/uncv.rs
@@ -105,10 +105,13 @@ impl Atom for Cmpd {
         for component in &self.components {
             component.component_type.encode(buf)?;
             if component.component_type >= 0x8000 {
-                let component_type_uri = component
-                    .component_type_uri
-                    .as_ref()
-                    .expect("Expected valid URI when component_type is >= 0x8000");
+                let component_type_uri =
+                    component
+                        .component_type_uri
+                        .as_ref()
+                        .ok_or(Error::MissingContent(
+                            "component_type_uri required when component_type >= 0x8000",
+                        ))?;
                 component_type_uri.as_str().encode(buf)?;
             }
         }

--- a/src/moov/trak/mdia/minf/stbl/subs.rs
+++ b/src/moov/trak/mdia/minf/stbl/subs.rs
@@ -134,26 +134,31 @@ impl AtomExt for Subs {
     }
 
     fn encode_body_ext<B: BufMut>(&self, buf: &mut B) -> Result<Self::Ext> {
-        let ext = match &self
-            .entries
-            .first()
-            .and_then(|e| e.subsamples.first())
-            .map(|s| &s.size)
-        {
-            Some(SubsSubsampleSize::U16(_)) => SubsExt {
-                version: SubsVersion::V0,
-                flags: self.flags,
-            },
-            Some(SubsSubsampleSize::U32(_)) => SubsExt {
-                version: SubsVersion::V1,
-                flags: self.flags,
-            },
-            // Should I store the version somewhere so that I can always decode and encode back to
-            // the exact same bytes?
-            None => SubsExt {
-                version: SubsVersion::default(),
-                flags: self.flags,
-            },
+        // The subsample_size width is a per-box property tied to the version, so
+        // every subsample must use the same variant. Picking the version from
+        // only the first subsample (as before) would silently emit U16-sized
+        // values for later U32 subsamples (or vice versa), producing output that
+        // fails to decode back to the same value.
+        let mut has_u16 = false;
+        let mut has_u32 = false;
+        for entry in &self.entries {
+            for subsample in &entry.subsamples {
+                match subsample.size {
+                    SubsSubsampleSize::U16(_) => has_u16 = true,
+                    SubsSubsampleSize::U32(_) => has_u32 = true,
+                }
+            }
+        }
+        let version = match (has_u16, has_u32) {
+            // Mixed widths can't be represented in a single subs box.
+            (true, true) => return Err(Error::OutOfRange),
+            (false, true) => SubsVersion::V1,
+            (true, false) => SubsVersion::V0,
+            (false, false) => SubsVersion::default(),
+        };
+        let ext = SubsExt {
+            version,
+            flags: self.flags,
         };
         (self.entries.len() as u32).encode(buf)?;
         for entry in &self.entries {
@@ -169,6 +174,12 @@ impl AtomExt for Subs {
                     1u8.encode(buf)?;
                 } else {
                     0u8.encode(buf)?;
+                }
+                // codec_specific_parameters is a fixed 4-byte field; decode reads
+                // exactly 4 bytes, so reject any other length rather than emit a
+                // box that can't be decoded back.
+                if subsample.codec_specific_parameters.len() != 4 {
+                    return Err(Error::OutOfRange);
                 }
                 subsample.codec_specific_parameters.encode(buf)?;
             }

--- a/src/prft.rs
+++ b/src/prft.rs
@@ -67,6 +67,12 @@ impl AtomExt for Prft {
     fn decode_body_ext<B: Buf>(buf: &mut B, ext: PrftExt) -> Result<Self> {
         let reference_track_id = u32::decode(buf)?;
         let ntp_timestamp = u64::decode(buf)?;
+        // The real_time flag (0x10) is only defined together with the
+        // consistent_offset flag (0x08); on its own it is nonconformant and
+        // would otherwise be misread as an unrelated ReferenceTime variant.
+        if ext.real_time && !ext.consistent_offset {
+            return Err(Error::Reserved);
+        }
         let utc_time_semantics = if ext.real_time && ext.consistent_offset {
             ReferenceTime::RealTime
         } else if ext.consistent_offset {

--- a/src/tokio/header.rs
+++ b/src/tokio/header.rs
@@ -33,7 +33,8 @@ impl AsyncReadFrom for Option<Header> {
                 let size = u64::from_be_bytes(buf);
                 let size = size.checked_sub(16).ok_or(Error::InvalidSize)?;
 
-                Some(size as usize)
+                // Avoid silent truncation of a 64-bit size on 32-bit targets.
+                Some(usize::try_from(size).map_err(|_| Error::TooLarge(kind))?)
             }
             _ => Some(size.checked_sub(8).ok_or(Error::InvalidSize)? as usize),
         };

--- a/src/types.rs
+++ b/src/types.rs
@@ -116,10 +116,14 @@ impl From<u24> for u32 {
 }
 
 impl TryFrom<u32> for u24 {
-    type Error = std::array::TryFromSliceError;
+    type Error = Error;
 
-    fn try_from(value: u32) -> std::result::Result<Self, Self::Error> {
-        Ok(Self(value.to_be_bytes()[1..].try_into()?))
+    fn try_from(value: u32) -> Result<Self> {
+        if value > Self::MAX {
+            return Err(Error::OutOfRange);
+        }
+        let b = value.to_be_bytes();
+        Ok(Self([b[1], b[2], b[3]]))
     }
 }
 
@@ -140,6 +144,10 @@ impl ToBytes for u24 {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct u48([u8; 6]);
 
+impl u48 {
+    pub const MAX: u64 = 0x0000_FFFF_FFFF_FFFF;
+}
+
 impl Decode for u48 {
     fn decode<B: Buf>(buf: &mut B) -> Result<Self> {
         Ok(Self(<[u8; 6]>::decode(buf)?))
@@ -153,10 +161,14 @@ impl Encode for u48 {
 }
 
 impl TryFrom<u64> for u48 {
-    type Error = std::array::TryFromSliceError;
+    type Error = Error;
 
-    fn try_from(value: u64) -> std::result::Result<Self, Self::Error> {
-        Ok(Self(value.to_be_bytes()[2..].try_into()?))
+    fn try_from(value: u64) -> Result<Self> {
+        if value > Self::MAX {
+            return Err(Error::OutOfRange);
+        }
+        let b = value.to_be_bytes();
+        Ok(Self([b[2], b[3], b[4], b[5], b[6], b[7]]))
     }
 }
 
@@ -237,7 +249,10 @@ where
         if self.dec.is_zero() {
             write!(f, "{:?}", self.int)
         } else {
-            write!(f, "{:?}", f64::from(self.int) / f64::from(self.dec))
+            // `int` is the integer part and `dec` is the raw fractional part
+            // scaled by 2^(bits in T), e.g. a 16.16 value uses FixedPoint<u16>.
+            let denom = 2f64.powi((std::mem::size_of::<T>() * 8) as i32);
+            write!(f, "{:?}", f64::from(self.int) + f64::from(self.dec) / denom)
         }
     }
 }


### PR DESCRIPTION
Addresses the low-severity, verified correctness items tracked in #197 (overflow/underflow edges, flag-fidelity round-trips, encode truncations).

Per the issue author's guidance, this prefers **spec-correctness over back-compat**: some previously-"successful" but malformed encodes now return `Err` instead of silently truncating. This is a `0.x` crate.

## Core / types
- `u24`/`u48` `TryFrom` now reject out-of-range values (new `Error::OutOfRange`) instead of silently truncating via `to_be_bytes()[1..]`; adds `u48::MAX`.
- `FixedPoint`'s `Debug` prints the true fixed-point value (`int + dec/2^bits`) rather than `int / dec`.
- `Header::encode` uses checked arithmetic (no overflow panic/wrap) and a 32-bit-safe largesize branch; decode paths (sync, `ReadFrom`, tokio) use `usize::try_from` so a 64-bit largesize no longer truncates on 32-bit targets.
- Atoms > 4 GiB now re-encode using the 64-bit `largesize` form instead of `Error::TooLarge` (the existing TODO). This adds a **new `BufMut::insert_slice` method** (implemented for `Vec`, `&mut T`, `BytesMut`) plus a shared `write_box_size` helper — a breaking change for external `BufMut` implementors.
- `Mdhd` gets a manual `Default` with `language: "und"` so `decode(encode(default)) == default` (an empty string isn't representable in the packed 15-bit form).

## Codecs
- **avcC** — extension block gated on `profile_idc` (the ISO 14496-15 High-profile set, incl. `244`) instead of leftover bytes, so trailing padding on a Baseline record no longer misparses as the chroma/bit-depth extension; `Avcc::new` emits the ext for High profiles; SPS (≤31) / PPS / NAL count & length overflow checks.
- **hvcC** — array / NALU count & length overflow checks.
- **av01** — fixes `initial_presentation_delay - 1` underflow and adds range checks (`seq_profile`, `seq_level_idx_0`, `chroma_sample_position`).
- **colr** — `full_range_flag` decoded as `byte & 0x80 != 0` (was `== 0x80`).
- **FLAC** — opaque metadata blocks (Padding/Application/SeekTable/CueSheet/Picture/Reserved/Forbidden) retain their payload and round-trip instead of being dropped, and the last-metadata-block flag is always emitted. **Variant shapes changed** (they now carry `Vec<u8>`).
- **eac3** — reject > 13-bit `data_rate` and empty/oversized substream lists.
- **uncv** — returns `Err` instead of panicking on a missing `component_type_uri`.
- **subs** — size version derived from *all* subsamples (errors on mixed U16/U32); `codec_specific_parameters` length enforced to 4.

## moov / moof
- **prft** — nonconformant `real_time` without `consistent_offset` now errors instead of misparsing as an unrelated `ReferenceTime`.
- **irot** — masks `angle & 0x03` on encode to match decode.
- **mfra** — `Mfro.parent_size` recomputed on encode; `tfra` drops the `.expect()` in favor of `?`.

## Not included / deviations
- The issue listed avcC High 4:4:4 as profile `144`; the real value is **`244`** (`144` isn't a profile). Both are included in the gate set for safety; `244` is what the `avcc_ext_2` fixture actually uses.
- **`Hmhd`** (hint media header) — already present on `main`, so no change here.
- **`String::decode` missing-NUL** — left lenient: many end-of-box string fields (`hdlr` name, `url` location, `auxc`, `cprt`) legitimately omit the trailing NUL in real files; strict decode would reject valid input, and re-encode already appends the NUL (box sizes recomputed, so benign).
- **Unknown FullBox flag bits** — not preserved (would require an "unknown flags" field on every `FullBox` for reserved bits that are ~always 0).
- **`minf` "exactly one media header"** — not enforced (risks rejecting real files; left as a separate decision).

## Testing
`cargo test --all-features` (240 pass, incl. new tests for the largesize header format, FLAC padding round-trip, and `Mdhd::default` round-trip), `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo fmt --check` all clean.

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)