### PR TITLE
Return errors for missing `infe` content types

### DIFF
--- a/src/meta/iinf.rs
+++ b/src/meta/iinf.rs
@@ -66,12 +66,11 @@ impl AtomExt for ItemInfoEntry {
             (self.item_id as u16).encode(buf)?;
             self.item_protection_index.encode(buf)?;
             self.item_name.as_str().encode(buf)?;
-            self.content_type.clone().unwrap().as_str().encode(buf)?;
-            self.content_encoding
-                .clone()
-                .unwrap_or("".to_string())
-                .as_str()
-                .encode(buf)?;
+            let content_type = self.content_type.as_deref().ok_or(Error::MissingContent(
+                "content_type required for infe version 0",
+            ))?;
+            content_type.encode(buf)?;
+            self.content_encoding.as_deref().unwrap_or("").encode(buf)?;
             if version == ItemInfoEntryVersion::V1 {
                 return Err(Error::Unsupported("infe version 1 extensions"));
             }
@@ -85,12 +84,11 @@ impl AtomExt for ItemInfoEntry {
             Some(self.item_type).encode(buf)?;
             self.item_name.as_str().encode(buf)?;
             if self.item_type == Some(FourCC::new(b"mime")) {
-                self.content_type.clone().unwrap().as_str().encode(buf)?;
-                self.content_encoding
-                    .clone()
-                    .unwrap_or("".to_string())
-                    .as_str()
-                    .encode(buf)?;
+                let content_type = self.content_type.as_deref().ok_or(Error::MissingContent(
+                    "content_type required with 'mime' item_type",
+                ))?;
+                content_type.encode(buf)?;
+                self.content_encoding.as_deref().unwrap_or("").encode(buf)?;
             } else if self.item_type == Some(FourCC::new(b"uri ")) {
                 let item_uri_type = self.item_uri_type.as_ref().ok_or(Error::MissingContent(
                     "item_uri_type required with 'uri ' item_type",
@@ -315,6 +313,52 @@ mod tests {
             }],
         };
         let mut buf = Vec::new();
+        assert!(matches!(
+            iinf.encode(&mut buf),
+            Err(Error::MissingContent(_))
+        ));
+    }
+
+    /// Rejects a version 0 item info entry when its required content type is missing.
+    #[test]
+    fn test_iinf_encode_v0_without_content_type_returns_error() {
+        let iinf = Iinf {
+            item_infos: vec![ItemInfoEntry {
+                item_id: 1,
+                item_protection_index: 0,
+                item_type: None,
+                item_name: "Item".to_string(),
+                content_type: None,
+                content_encoding: None,
+                item_uri_type: None,
+                item_not_in_presentation: false,
+            }],
+        };
+        let mut buf = Vec::new();
+
+        assert!(matches!(
+            iinf.encode(&mut buf),
+            Err(Error::MissingContent(_))
+        ));
+    }
+
+    /// Rejects a `mime` item info entry when its required content type is missing.
+    #[test]
+    fn test_iinf_encode_mime_without_content_type_returns_error() {
+        let iinf = Iinf {
+            item_infos: vec![ItemInfoEntry {
+                item_id: 1,
+                item_protection_index: 0,
+                item_type: Some(FourCC::new(b"mime")),
+                item_name: "Item".to_string(),
+                content_type: None,
+                content_encoding: None,
+                item_uri_type: None,
+                item_not_in_presentation: false,
+            }],
+        };
+        let mut buf = Vec::new();
+
         assert!(matches!(
             iinf.encode(&mut buf),
             Err(Error::MissingContent(_))


### PR DESCRIPTION
Split from #199. Refs #179.

## What changed

- Return `Error::MissingContent` when encoding a version 0 `infe` entry without its required content type.
- Return the same error for `mime` entries without a content type.
- Avoid cloning optional strings while encoding.
- Add regression tests for both invalid encoder states.

## Why

These required fields were unwrapped during encoding, so invalid caller-provided state could panic instead of returning a normal error.

## Impact

Encoding malformed `infe` entries now fails predictably without changing valid output.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-features` (252 unit tests and 3 doctests passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check main...HEAD`