### PR TITLE
fix: consistency check vpcC matrix coefficients and chroma subsampling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -65,6 +65,9 @@ pub enum Error {
 
     #[error("missing required content: {0}")]
     MissingContent(&'static str),
+
+    #[error("invalid parameter combination: {0}")]
+    InvalidCombination(&'static str),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/moov/trak/mdia/minf/stbl/stsd/vp9/vpcc.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/vp9/vpcc.rs
@@ -6,7 +6,7 @@ ext! {
     flags: {}
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VpcC {
     pub profile: u8,
@@ -20,6 +20,21 @@ pub struct VpcC {
     pub codec_initialization_data: Vec<u8>,
 }
 
+impl Default for VpcC {
+    fn default() -> Self {
+        Self {
+            profile: 0,
+            level: 0, /* undefined */
+            bit_depth: 8,
+            chroma_subsampling: 0,
+            video_full_range_flag: false,
+            color_primaries: 1,          /* BT.709-6 */
+            transfer_characteristics: 1, /* BT.709-6 */
+            matrix_coefficients: 1,      /* BT.709-6 */
+            codec_initialization_data: Default::default(),
+        }
+    }
+}
 impl AtomExt for VpcC {
     const KIND_EXT: FourCC = FourCC::new(b"vpcC");
 
@@ -55,6 +70,11 @@ impl AtomExt for VpcC {
         if self.chroma_subsampling > 3 {
             return Err(Error::Reserved);
         }
+        if (self.matrix_coefficients == 0) && (self.chroma_subsampling != 3) {
+            return Err(Error::InvalidCombination(
+                "Matrix coefficient 0 (RGB) is only valid with chroma subsampling 3 (4:4:4)",
+            ));
+        }
 
         self.profile.encode(buf)?;
         self.level.encode(buf)?;
@@ -86,7 +106,7 @@ mod tests {
             video_full_range_flag: false,
             color_primaries: 0,
             transfer_characteristics: 0,
-            matrix_coefficients: 0,
+            matrix_coefficients: 1,
             codec_initialization_data: vec![],
         };
         let mut buf = Vec::new();
@@ -130,5 +150,42 @@ mod tests {
 
             assert!(matches!(vpcc.encode(&mut Vec::new()), Err(Error::Reserved)));
         }
+    }
+
+    #[test]
+    fn test_vpcc_12_bit() {
+        let expected = VpcC {
+            profile: 2,
+            level: 62,
+            bit_depth: 12,
+            chroma_subsampling: 3,
+            video_full_range_flag: false,
+            color_primaries: 0,
+            transfer_characteristics: 0,
+            matrix_coefficients: 0,
+            codec_initialization_data: vec![],
+        };
+        let mut buf = Vec::new();
+        expected.encode(&mut buf).unwrap();
+
+        let mut buf = buf.as_ref();
+        let decoded = VpcC::decode(&mut buf).unwrap();
+        assert_eq!(decoded, expected);
+    }
+
+    #[test]
+    fn test_vpcc_rejects_rgb_subsampling() {
+        let vpcc = VpcC {
+            chroma_subsampling: 1,
+            matrix_coefficients: 0,
+            ..Default::default()
+        };
+
+        assert!(matches!(
+            vpcc.encode(&mut Vec::new()),
+            Err(Error::InvalidCombination(
+                "Matrix coefficient 0 (RGB) is only valid with chroma subsampling 3 (4:4:4)"
+            ))
+        ));
     }
 }


### PR DESCRIPTION
From  https://www.webmproject.org/vp9/mp4/#fn:1

>  If `matrixCoefficients` is 0 (RGB), then chroma subsampling MUST be 3 (4:4:4).

That means that we can't really derive Default, because the default is zero.