### PR TITLE
udta: dispatch children by namespace

### DIFF
--- a/src/atom.rs
+++ b/src/atom.rs
@@ -207,6 +207,9 @@ macro_rules! nested {
                         unknown => Self::decode_unknown(&unknown)?,
                     }
                 }
+                // Tolerate a sub-header padding remainder (e.g. a QuickTime zero
+                // terminator) after the child boxes.
+                skip_trailing_padding(buf);
 
                 Ok(Self {
                     $([<$required:lower>]: [<$required:lower>].ok_or(Error::MissingBox($required::KIND))? ,)*

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -55,6 +55,22 @@ impl<T: Buf + ?Sized> Buf for &mut T {
     }
 }
 
+/// Drain trailing padding left after an atom's child boxes.
+///
+/// Some muxers — QuickTime in particular — append a few bytes (commonly a
+/// 4-byte zero "terminator") after the last child box of a container atom or
+/// sample entry. Such a remainder is shorter than a box header (8 bytes), so it
+/// cannot be a box and can only be padding: drain it instead of failing the
+/// whole atom with [`Error::UnderDecode`](crate::Error::UnderDecode), matching
+/// ffmpeg, GPAC and other demuxers. A remainder of 8 or more bytes is left
+/// untouched so genuine trailing corruption is still reported.
+pub(crate) fn skip_trailing_padding<B: Buf>(buf: &mut B) {
+    let n = buf.remaining();
+    if n > 0 && n < 8 {
+        buf.advance(n);
+    }
+}
+
 #[cfg(feature = "bytes")]
 impl Buf for bytes::Bytes {
     fn remaining(&self) -> usize {

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -106,6 +106,7 @@ impl Atom for Meta {
         while let Some(atom) = Any::decode_maybe(buf)? {
             items.push(atom);
         }
+        skip_trailing_padding(buf);
 
         Ok(Self { hdlr, items })
     }
@@ -139,6 +140,28 @@ mod tests {
         let mut buf = buf.as_ref();
         let output = Meta::decode(&mut buf).unwrap();
         assert_eq!(output, expected);
+    }
+
+    // The hand-written `meta` decode loop must also tolerate a sub-header
+    // padding remainder after its child boxes.
+    #[test]
+    fn test_meta_trailing_padding() {
+        let meta = Meta {
+            hdlr: Hdlr {
+                handler: b"mdir".into(),
+                name: "".into(),
+            },
+            items: Vec::new(),
+        };
+        let mut buf = Vec::new();
+        meta.encode(&mut buf).unwrap();
+        buf.extend_from_slice(&[0, 0, 0, 0]);
+        let size = (buf.len() as u32).to_be_bytes();
+        buf[0..4].copy_from_slice(&size);
+
+        let decoded =
+            Meta::decode(&mut buf.as_slice()).expect("trailing padding must be tolerated");
+        assert_eq!(decoded, meta);
     }
 
     #[test]

--- a/src/mfra/mod.rs
+++ b/src/mfra/mod.rs
@@ -40,6 +40,8 @@ impl Atom for Mfra {
                 unknown => Self::decode_unknown(&unknown)?,
             }
         }
+        skip_trailing_padding(buf);
+
         Ok(Self {
             mfro: mfro.ok_or(Error::MissingBox(Mfro::KIND))?,
             tfra,

--- a/src/moov/trak/edts/mod.rs
+++ b/src/moov/trak/edts/mod.rs
@@ -18,3 +18,22 @@ impl Atom for Edts {
         multiple: [],
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A container decoded through the `nested!` macro must tolerate a sub-header
+    // padding remainder (e.g. a QuickTime zero terminator) after its children.
+    #[test]
+    fn test_edts_trailing_padding() {
+        let mut buf = Vec::new();
+        Edts::default().encode(&mut buf).unwrap();
+        buf.extend_from_slice(&[0, 0, 0, 0]);
+        let size = (buf.len() as u32).to_be_bytes();
+        buf[0..4].copy_from_slice(&size);
+
+        let edts = Edts::decode(&mut buf.as_slice()).expect("trailing padding must be tolerated");
+        assert_eq!(edts, Edts::default());
+    }
+}

--- a/src/moov/trak/mdia/minf/stbl/stsd/ac3.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/ac3.rs
@@ -23,6 +23,7 @@ impl Atom for Ac3 {
                 unknown => Self::decode_unknown(&unknown)?,
             }
         }
+        skip_trailing_padding(buf);
 
         Ok(Self {
             audio,

--- a/src/moov/trak/mdia/minf/stbl/stsd/amr/samr.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/amr/samr.rs
@@ -20,6 +20,7 @@ impl Atom for Samr {
                 unknown => Self::decode_unknown(&unknown)?,
             }
         }
+        skip_trailing_padding(buf);
 
         Ok(Self {
             amrsampleentry,

--- a/src/moov/trak/mdia/minf/stbl/stsd/av01.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/av01.rs
@@ -1,5 +1,7 @@
 use crate::coding::{Decode, Encode};
-use crate::{Any, Atom, Buf, BufMut, Ccst, DecodeMaybe, Error, FourCC, Result};
+use crate::{
+    skip_trailing_padding, Any, Atom, Buf, BufMut, Ccst, DecodeMaybe, Error, FourCC, Result,
+};
 
 use super::{Btrt, Colr, Pasp, Taic, Visual};
 
@@ -38,6 +40,7 @@ impl Atom for Av01 {
                 unknown => Self::decode_unknown(&unknown)?,
             }
         }
+        skip_trailing_padding(buf);
 
         Ok(Av01 {
             visual,

--- a/src/moov/trak/mdia/minf/stbl/stsd/eac3.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/eac3.rs
@@ -23,6 +23,7 @@ impl Atom for Eac3 {
                 unknown => Self::decode_unknown(&unknown)?,
             }
         }
+        skip_trailing_padding(buf);
 
         Ok(Self {
             audio,

--- a/src/moov/trak/mdia/minf/stbl/stsd/flac.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/flac.rs
@@ -20,6 +20,7 @@ impl Atom for Flac {
                 unknown => Self::decode_unknown(&unknown)?,
             }
         }
+        skip_trailing_padding(buf);
 
         Ok(Self {
             audio,

--- a/src/moov/trak/mdia/minf/stbl/stsd/h264/avc1.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/h264/avc1.rs
@@ -35,6 +35,7 @@ impl Atom for Avc1 {
                 unknown => Self::decode_unknown(&unknown)?,
             }
         }
+        skip_trailing_padding(buf);
 
         Ok(Avc1 {
             visual,
@@ -101,6 +102,68 @@ mod tests {
         let mut buf = buf.as_ref();
         let decoded = Avc1::decode(&mut buf).unwrap();
         assert_eq!(decoded, expected);
+    }
+
+    // QuickTime muxers append a few bytes of padding (commonly a 4-byte zero
+    // terminator) after a sample entry's child boxes.
+    #[test]
+    fn test_avc1_trailing_padding() {
+        let base = Avc1 {
+            visual: Visual {
+                data_reference_index: 1,
+                width: 320,
+                height: 240,
+                horizresolution: 0x48.into(),
+                vertresolution: 0x48.into(),
+                frame_count: 1,
+                compressor: "".into(),
+                depth: 24,
+            },
+            avcc: Avcc {
+                configuration_version: 1,
+                avc_profile_indication: 100,
+                profile_compatibility: 0,
+                avc_level_indication: 13,
+                length_size: 4,
+                sequence_parameter_sets: vec![vec![0x67, 0x64, 0x00, 0x0D]],
+                picture_parameter_sets: vec![vec![0x68, 0xEB, 0xE3, 0xCB]],
+                ..Default::default()
+            },
+            colr: Some(Colr::default()),
+            ..Default::default()
+        };
+
+        // Build the entry with `pad` trailing zero bytes inside the box.
+        let with_padding = |pad: usize| {
+            let mut buf = Vec::new();
+            base.encode(&mut buf).unwrap();
+            buf.extend(std::iter::repeat_n(0u8, pad));
+            let size = (buf.len() as u32).to_be_bytes();
+            buf[0..4].copy_from_slice(&size);
+            buf
+        };
+
+        // A 1..=7-byte zero remainder is a sub-header fragment (too short to be a
+        // box) — `skip_trailing_padding` drains it and the entry decodes back to
+        // the original value.
+        for pad in [1usize, 4, 7] {
+            let buf = with_padding(pad);
+            let decoded = Avc1::decode(&mut buf.as_slice())
+                .unwrap_or_else(|e| panic!("{pad}-byte trailing padding must be tolerated: {e:?}"));
+            assert_eq!(
+                decoded, base,
+                "{pad}-byte padding dropped, entry otherwise unchanged"
+            );
+        }
+
+        // 8 zero bytes are a well-formed box header (size 0, null FourCC), NOT
+        // sub-header padding — `skip_trailing_padding`'s `<8`-byte contract does
+        // not drain them, so the strict child loop must still reject the entry.
+        let buf = with_padding(8);
+        assert!(
+            Avc1::decode(&mut buf.as_slice()).is_err(),
+            "an 8-byte remainder is a box header, not padding, and must be rejected"
+        );
     }
 
     #[test]

--- a/src/moov/trak/mdia/minf/stbl/stsd/hevc/hev1.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/hevc/hev1.rs
@@ -38,6 +38,7 @@ impl Atom for Hev1 {
                 unknown => Self::decode_unknown(&unknown)?,
             }
         }
+        skip_trailing_padding(buf);
 
         Ok(Hev1 {
             visual,

--- a/src/moov/trak/mdia/minf/stbl/stsd/hevc/hvc1.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/hevc/hvc1.rs
@@ -42,6 +42,7 @@ impl Atom for Hvc1 {
                 unknown => Self::decode_unknown(&unknown)?,
             }
         }
+        skip_trailing_padding(buf);
 
         Ok(Self {
             visual,

--- a/src/moov/trak/mdia/minf/stbl/stsd/mp4a/mod.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/mp4a/mod.rs
@@ -37,6 +37,7 @@ impl Atom for Mp4a {
                 unknown => Self::decode_unknown(&unknown)?,
             }
         }
+        skip_trailing_padding(buf);
 
         Ok(Mp4a {
             audio,

--- a/src/moov/trak/mdia/minf/stbl/stsd/opus.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/opus.rs
@@ -25,6 +25,7 @@ impl Atom for Opus {
                 unknown => Self::decode_unknown(&unknown)?,
             }
         }
+        skip_trailing_padding(buf);
 
         Ok(Self {
             audio,

--- a/src/moov/trak/mdia/minf/stbl/stsd/tx3g.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/tx3g.rs
@@ -79,6 +79,7 @@ impl Atom for Tx3g {
                 unknown => Self::decode_unknown(&unknown)?,
             }
         }
+        skip_trailing_padding(buf);
 
         Ok(Tx3g {
             data_reference_index,

--- a/src/moov/trak/mdia/minf/stbl/stsd/uncv.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/uncv.rs
@@ -37,6 +37,7 @@ impl Atom for Uncv {
                 unknown => Self::decode_unknown(&unknown)?,
             }
         }
+        skip_trailing_padding(buf);
 
         Ok(Uncv {
             visual,

--- a/src/moov/trak/mdia/minf/stbl/stsd/vp9/vp08.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/vp9/vp08.rs
@@ -30,6 +30,7 @@ impl Atom for Vp08 {
                 unknown => Self::decode_unknown(&unknown)?,
             }
         }
+        skip_trailing_padding(buf);
 
         Ok(Self {
             visual,

--- a/src/moov/trak/mdia/minf/stbl/stsd/vp9/vp09.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/vp9/vp09.rs
@@ -30,6 +30,7 @@ impl Atom for Vp09 {
                 unknown => Self::decode_unknown(&unknown)?,
             }
         }
+        skip_trailing_padding(buf);
 
         Ok(Self {
             visual,

--- a/src/moov/trak/mdia/minf/stbl/stsd/wvtt.rs
+++ b/src/moov/trak/mdia/minf/stbl/stsd/wvtt.rs
@@ -70,6 +70,7 @@ impl Atom for Wvtt {
                 unknown => Self::decode_unknown(&unknown)?,
             }
         }
+        skip_trailing_padding(buf);
 
         Ok(Self {
             plaintext,

--- a/src/moov/udta/mod.rs
+++ b/src/moov/udta/mod.rs
@@ -22,10 +22,57 @@ pub struct Udta {
 impl Atom for Udta {
     const KIND: FourCC = FourCC::new(b"udta");
 
-    nested! {
-        required: [ ],
-        optional: [ Cprt, Meta, Kind, Rtng ],
-        multiple: [ ],
+    fn decode_body<B: Buf>(buf: &mut B) -> Result<Self> {
+        let mut cprt = None;
+        let mut kind = None;
+        let mut meta = None;
+        let mut rtng = None;
+
+        // `udta` is a free-form user-data container. QuickTime writes a
+        // track-name `name` box here, whose fourcc collides with the iTunes
+        // `ilst` Name item in the global atom table, so dispatch children by
+        // header against the udta namespace only — the same shape as
+        // `Ilst::decode_body` — rather than through `Any`. Unknown children go
+        // to `decode_unknown` (a warning by default, an error under strict).
+        while let Some(header) = Header::decode_maybe(buf)? {
+            let size = header.size.unwrap_or(buf.remaining());
+            if size > buf.remaining() {
+                // A child whose declared size exceeds what remains is truncated.
+                return Err(Error::OutOfBounds);
+            }
+            match header.kind {
+                Cprt::KIND => cprt = Some(Cprt::decode_atom(&header, buf)?),
+                Kind::KIND => kind = Some(Kind::decode_atom(&header, buf)?),
+                Meta::KIND => meta = Some(Meta::decode_atom(&header, buf)?),
+                Rtng::KIND => rtng = Some(Rtng::decode_atom(&header, buf)?),
+                // `free`/`skip` are padding boxes; drop them.
+                Free::KIND | Skip::KIND => {
+                    buf.advance(size);
+                }
+                unknown => {
+                    let body = Vec::decode(&mut buf.slice(size))?;
+                    buf.advance(size);
+                    Self::decode_unknown(&Any::Unknown(unknown, body))?;
+                }
+            }
+        }
+        // Drop any sub-header padding remainder after the children.
+        skip_trailing_padding(buf);
+
+        Ok(Udta {
+            cprt,
+            kind,
+            meta,
+            rtng,
+        })
+    }
+
+    fn encode_body<B: BufMut>(&self, buf: &mut B) -> Result<()> {
+        self.cprt.encode(buf)?;
+        self.meta.encode(buf)?;
+        self.kind.encode(buf)?;
+        self.rtng.encode(buf)?;
+        Ok(())
     }
 }
 
@@ -145,5 +192,43 @@ mod tests {
         udta.encode(&mut buf).unwrap();
 
         assert_eq!(buf, ENCODED_UDTA_WITH_KIND);
+    }
+
+    // A track-level QuickTime `udta` holding an empty (4-null-byte) track-name
+    // `name` box. Its fourcc collides with the iTunes `ilst` Name item in the
+    // global atom table.
+    const ENCODED_UDTA_WITH_QT_NAME: &[u8] = &[
+        0x00, 0x00, 0x00, 0x14, 0x75, 0x64, 0x74, 0x61, // udta, size 20
+        0x00, 0x00, 0x00, 0x0c, 0x6e, 0x61, 0x6d, 0x65, // name, size 12
+        0x00, 0x00, 0x00, 0x00, // body: empty QuickTime track-name string
+    ];
+
+    // A sub-header padding remainder after a `udta`'s children must be skipped
+    // as padding while the real children still decode.
+    #[test]
+    fn test_udta_trailing_padding() {
+        let mut buf = ENCODED_UDTA_WITH_CPRT.to_vec();
+        buf.extend_from_slice(&[0, 0, 0, 0]);
+        let size = (buf.len() as u32).to_be_bytes();
+        buf[0..4].copy_from_slice(&size);
+
+        let udta = Udta::decode(&mut buf.as_slice()).expect("trailing padding must be tolerated");
+        assert!(
+            udta.cprt.is_some(),
+            "the real child still decodes, the padding is dropped"
+        );
+    }
+
+    #[test]
+    fn test_udta_quicktime_name_not_misparsed() {
+        // The udta-namespace dispatch must NOT route `name` to the global
+        // `Any` table's ilst Name item (which would UnderDecode the 4-byte
+        // body). Under `cfg(test)` an unknown child is an error, proving the
+        // atom is treated as unknown-to-udta rather than misparsed as ilst.
+        let mut buf = std::io::Cursor::new(ENCODED_UDTA_WITH_QT_NAME);
+        match Udta::decode(&mut buf) {
+            Err(Error::UnexpectedBox(kind)) => assert_eq!(kind, FourCC::new(b"name")),
+            other => panic!("expected UnexpectedBox(name), got {other:?}"),
+        }
     }
 }

--- a/src/moov/udta/mod.rs
+++ b/src/moov/udta/mod.rs
@@ -13,20 +13,24 @@ use crate::*;
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Udta {
-    pub cprt: Option<Cprt>,
-    pub kind: Option<Kind>,
+    /// Zero or more, one per language (ISO/IEC 14496-12 §8.10.2).
+    pub cprt: Vec<Cprt>,
+    /// Zero or more, one per role/kind label (ISO/IEC 14496-12 §8.10.4).
+    pub kind: Vec<Kind>,
+    /// Zero or one (ISO/IEC 14496-12 §8.11.1).
     pub meta: Option<Meta>,
-    pub rtng: Option<Rtng>,
+    /// Zero or more, one per language (3GPP TS 26.244 clause 8).
+    pub rtng: Vec<Rtng>,
 }
 
 impl Atom for Udta {
     const KIND: FourCC = FourCC::new(b"udta");
 
     fn decode_body<B: Buf>(buf: &mut B) -> Result<Self> {
-        let mut cprt = None;
-        let mut kind = None;
+        let mut cprt = Vec::new();
+        let mut kind = Vec::new();
         let mut meta = None;
-        let mut rtng = None;
+        let mut rtng = Vec::new();
 
         // `udta` is a free-form user-data container. QuickTime writes a
         // track-name `name` box here, whose fourcc collides with the iTunes
@@ -40,11 +44,23 @@ impl Atom for Udta {
                 // A child whose declared size exceeds what remains is truncated.
                 return Err(Error::OutOfBounds);
             }
+            // Multiplicity follows the specs: `cprt` and `kind` are "zero or
+            // more" (ISO/IEC 14496-12 §8.10.2 — one copyright notice per
+            // language — and §8.10.4 — one box per role value), and 3GPP
+            // TS 26.244 clause 8 admits each asset box (`rtng` included) once
+            // per language, so repeats accumulate. `meta` is "zero or one" per
+            // container (ISO/IEC 14496-12 §8.11.1), so a second one is
+            // malformed.
             match header.kind {
-                Cprt::KIND => cprt = Some(Cprt::decode_atom(&header, buf)?),
-                Kind::KIND => kind = Some(Kind::decode_atom(&header, buf)?),
-                Meta::KIND => meta = Some(Meta::decode_atom(&header, buf)?),
-                Rtng::KIND => rtng = Some(Rtng::decode_atom(&header, buf)?),
+                Cprt::KIND => cprt.push(Cprt::decode_atom(&header, buf)?),
+                Kind::KIND => kind.push(Kind::decode_atom(&header, buf)?),
+                Meta::KIND => {
+                    if meta.is_some() {
+                        return Err(Error::DuplicateBox(Meta::KIND));
+                    }
+                    meta = Some(Meta::decode_atom(&header, buf)?);
+                }
+                Rtng::KIND => rtng.push(Rtng::decode_atom(&header, buf)?),
                 // `free`/`skip` are padding boxes; drop them.
                 Free::KIND | Skip::KIND => {
                     buf.advance(size);
@@ -83,10 +99,10 @@ mod tests {
     #[test]
     fn test_udta_empty() {
         let expected = Udta {
-            cprt: None,
+            cprt: vec![],
             meta: None,
-            kind: None,
-            rtng: None,
+            kind: vec![],
+            rtng: vec![],
         };
 
         let mut buf = Vec::new();
@@ -100,10 +116,10 @@ mod tests {
     #[test]
     fn test_udta() {
         let expected = Udta {
-            cprt: Some(Cprt {
+            cprt: vec![Cprt {
                 language: "und".into(),
                 notice: "MIT or Apache".into(),
-            }),
+            }],
             meta: Some(Meta {
                 hdlr: Hdlr {
                     handler: FourCC::new(b"fake"),
@@ -111,16 +127,16 @@ mod tests {
                 },
                 items: vec![],
             }),
-            kind: Some(Kind {
+            kind: vec![Kind {
                 scheme_uri: "http://www.w3.org/TR/html5/".into(),
                 value: "".into(),
-            }),
-            rtng: Some(Rtng {
+            }],
+            rtng: vec![Rtng {
                 entity: b"BBFC".into(),
                 criteria: b"PG13".into(),
                 language: "eng".into(),
                 rating_info: "test info".into(),
-            }),
+            }],
         };
 
         let mut buf = Vec::new();
@@ -152,7 +168,7 @@ mod tests {
         assert_eq!(
             udta,
             Udta {
-                cprt: Some(Cprt { language: "und".into(), notice: "ENST IsoMedia Conformance Files - ENST (c) 2006 - Rights released for ISO Conformance use".into() }),
+                cprt: vec![Cprt { language: "und".into(), notice: "ENST IsoMedia Conformance Files - ENST (c) 2006 - Rights released for ISO Conformance use".into() }],
                 ..Default::default()
             }
         );
@@ -180,10 +196,10 @@ mod tests {
         assert_eq!(
             udta,
             Udta {
-                kind: Some(Kind {
+                kind: vec![Kind {
                     scheme_uri: "urn:mpeg:dash:role:2011".into(),
                     value: "main".into()
-                }),
+                }],
                 ..Default::default()
             }
         );
@@ -213,8 +229,9 @@ mod tests {
         buf[0..4].copy_from_slice(&size);
 
         let udta = Udta::decode(&mut buf.as_slice()).expect("trailing padding must be tolerated");
-        assert!(
-            udta.cprt.is_some(),
+        assert_eq!(
+            udta.cprt.len(),
+            1,
             "the real child still decodes, the padding is dropped"
         );
     }
@@ -229,6 +246,87 @@ mod tests {
         match Udta::decode(&mut buf) {
             Err(Error::UnexpectedBox(kind)) => assert_eq!(kind, FourCC::new(b"name")),
             other => panic!("expected UnexpectedBox(name), got {other:?}"),
+        }
+    }
+
+    // Repeated `cprt`/`kind`/`rtng` children are spec-legal — ISO/IEC 14496-12
+    // declares both CopyrightBox (§8.10.2) and KindBox (§8.10.4) as quantity
+    // "zero or more" (one copyright per language, one kind per role value),
+    // and 3GPP TS 26.244 clause 8 admits "zero or more sub-boxes of each kind,
+    // zero or one for each language" of the asset boxes, `rtng` included.
+    // Repeats must accumulate — not error, not overwrite each other.
+    #[test]
+    fn test_udta_repeated_children() {
+        let expected = Udta {
+            cprt: vec![
+                Cprt {
+                    language: "eng".into(),
+                    notice: "All rights reserved".into(),
+                },
+                Cprt {
+                    language: "fra".into(),
+                    notice: "Tous droits réservés".into(),
+                },
+            ],
+            kind: vec![
+                Kind {
+                    scheme_uri: "urn:mpeg:dash:role:2011".into(),
+                    value: "main".into(),
+                },
+                Kind {
+                    scheme_uri: "urn:mpeg:dash:role:2011".into(),
+                    value: "caption".into(),
+                },
+            ],
+            meta: None,
+            rtng: vec![
+                Rtng {
+                    entity: b"BBFC".into(),
+                    criteria: b"PG13".into(),
+                    language: "eng".into(),
+                    rating_info: "parental guidance".into(),
+                },
+                Rtng {
+                    entity: b"BBFC".into(),
+                    criteria: b"PG13".into(),
+                    language: "fra".into(),
+                    rating_info: "accord parental".into(),
+                },
+            ],
+        };
+
+        let mut buf = Vec::new();
+        expected.encode(&mut buf).unwrap();
+
+        let mut buf = buf.as_ref();
+        let output = Udta::decode(&mut buf).unwrap();
+        assert_eq!(output, expected);
+    }
+
+    // `meta` is quantity "zero or one" per container (ISO/IEC 14496-12
+    // §8.11.1) — unlike the repeatable children above, a second one is
+    // malformed and must be rejected, not silently overwritten.
+    #[test]
+    fn test_udta_duplicate_meta() {
+        let meta = Meta {
+            hdlr: Hdlr {
+                handler: FourCC::new(b"fake"),
+                name: "".into(),
+            },
+            items: vec![],
+        };
+        let mut body = Vec::new();
+        meta.encode(&mut body).unwrap();
+        meta.encode(&mut body).unwrap();
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&((body.len() + 8) as u32).to_be_bytes());
+        bytes.extend_from_slice(b"udta");
+        bytes.extend_from_slice(&body);
+
+        match Udta::decode(&mut bytes.as_slice()) {
+            Err(Error::DuplicateBox(kind)) => assert_eq!(kind, Meta::KIND),
+            other => panic!("expected DuplicateBox(meta), got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
`udta` is a free-form user-data container whose children are context-specific. QuickTime writes a track-name `name` box in a track's `udta`, and its fourcc collides with the iTunes `ilst` `Name` item in the global atom table; routing `udta` children through that table misparses the QuickTime `name` (its string decoder stops at the first NUL of an empty name) and fails the `moov` with `UnderDecode(name)`.

`Udta::decode_body` now dispatches children by header against the udta namespace only (`cprt`, `kind`, `meta`, `rtng`; `free`/`skip` treated as padding; everything else via `decode_unknown`), the same shape as `Ilst::decode_body` from #172. A child whose declared size exceeds what remains is rejected as truncated.

**Review follow-up (breaking):** child multiplicity now follows the specs — `cprt` and `kind` are quantity "zero or more" (ISO/IEC 14496-12 §8.10.2 / §8.10.4: one copyright notice per language, one kind box per role value) and `rtng` may repeat per language (3GPP TS 26.244 clause 8), so those `Udta` fields changed from `Option<T>` to `Vec<T>` and repeats accumulate. `meta` stays "zero or one" (§8.11.1): a second one is rejected with `Error::DuplicateBox`. The old `nested!` decode rejected repeats of all four, failing whole `moov`s over spec-valid files such as bilingual copyright notices.

_Split out of the trailing-padding PR (#173) and stacked on it — the diff shows the trailing-padding commit until #173 merges._
